### PR TITLE
fix: popping  connect email modal when refreshed

### DIFF
--- a/components/mail/empty-state.tsx
+++ b/components/mail/empty-state.tsx
@@ -9,6 +9,7 @@ import {
 import { Archive, ArchiveX, FileText, Inbox, LucideIcon, Plus, Send, Trash2 } from "lucide-react";
 import { emailProviders } from "@/constants/emailProviders";
 import { useConnections } from "@/hooks/use-connections";
+import { MailThreadSkeleton } from "./mail-skeleton";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import { useMemo } from "react";
@@ -91,10 +92,13 @@ function EmptyState({ folder, className }: EmptyStateProps) {
   const config = FOLDER_CONFIGS[folder] ?? FOLDER_CONFIGS.inbox;
   const Icon = config.icon;
   const connections = useConnections();
-  const noConnection = useMemo(
-    () => !connections?.data || connections?.data?.length === 0,
-    [connections?.data],
-  );
+  const noConnection = !connections?.data || connections?.data?.length === 0;
+
+  console.log(connections, "from empty state");
+  console.log(noConnection, "from empty state");
+  if (connections.isLoading) {
+    return <MailThreadSkeleton />;
+  }
 
   return (
     <div>

--- a/components/mail/mail-skeleton.tsx
+++ b/components/mail/mail-skeleton.tsx
@@ -85,3 +85,26 @@ export const MailHeaderSkeleton = ({ isFullscreen }: { isFullscreen?: boolean })
     </div>
   );
 };
+
+export const MailThreadSkeleton = () => {
+  return (
+    <div className="flex flex-col">
+      {[...Array(8)].map((_, i) => (
+        <div key={i} className="flex flex-col px-4 py-3">
+          <div className="flex w-full items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Skeleton className="h-4 w-24" />
+            </div>
+            <Skeleton className="h-3 w-12" />
+          </div>
+          <Skeleton className="mt-2 h-3 w-32" />
+          <Skeleton className="mt-2 h-3 w-full" />
+          <div className="mt-2 flex gap-2">
+            <Skeleton className="h-4 w-16 rounded-full" />
+            <Skeleton className="h-4 w-16 rounded-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};

--- a/components/mail/mail.tsx
+++ b/components/mail/mail.tsx
@@ -25,6 +25,7 @@ import { useSearchValue } from "@/hooks/use-search-value";
 import { MailList } from "@/components/mail/mail-list";
 import { useMail } from "@/components/mail/use-mail";
 import { SidebarToggle } from "../ui/sidebar-toggle";
+import { MailThreadSkeleton } from "./mail-skeleton";
 import { Skeleton } from "@/components/ui/skeleton";
 import { type Mail } from "@/components/mail/data";
 import { useSearchParams } from "next/navigation";
@@ -213,24 +214,7 @@ export function Mail({ folder }: MailProps) {
 
               <div className="h-[calc(100svh-(8px+8px+14px+44px-2px))] overflow-scroll p-2 pt-0">
                 {isLoading || isTransitioning ? (
-                  <div className="flex flex-col">
-                    {[...Array(8)].map((_, i) => (
-                      <div key={i} className="flex flex-col px-4 py-3">
-                        <div className="flex w-full items-center justify-between">
-                          <div className="flex items-center gap-2">
-                            <Skeleton className="h-4 w-24" />
-                          </div>
-                          <Skeleton className="h-3 w-12" />
-                        </div>
-                        <Skeleton className="mt-2 h-3 w-32" />
-                        <Skeleton className="mt-2 h-3 w-full" />
-                        <div className="mt-2 flex gap-2">
-                          <Skeleton className="h-4 w-16 rounded-full" />
-                          <Skeleton className="h-4 w-16 rounded-full" />
-                        </div>
-                      </div>
-                    ))}
-                  </div>
+                  <MailThreadSkeleton />
                 ) : (
                   <MailList
                     items={threadsResponse?.threads || []}


### PR DESCRIPTION
before:
when refreshed from mail/inbox connect email modal pops due to unused loading state.

https://github.com/user-attachments/assets/65c5d7e7-9d76-481d-9734-9e691aa84c9d

after : 
fixed it with loading state and added emailthread skeleton for it