### PR TITLE
fix: ordered the bash executions for initial setup in readme. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,6 @@ Before running the application, you'll need to set up several services and envir
      rm pnpm-lock.yaml
      ```
 
-   - Use `pnpm db:studio` to view and manage your data
 
 2. **Better Auth Setup**
 
@@ -248,6 +247,8 @@ Drizzle will apply the schema migrations set in `.env`
 ```bash
 pnpm db:push
 ```
+
+- Use `pnpm db:studio` to view and manage your data
 
 ### Running Locally
 


### PR DESCRIPTION
The current order of bash executions is faulty in that `pnpm db:push` and `pnpm dev` are executed before populating **.env** with the necessary auth parameters, resulting in an error
![db_push](https://github.com/user-attachments/assets/326df183-3be1-4f80-897d-c91887bf3032)

The scripts are just executed later on after setting up OAuth so that drizzle has the variables while applying the schema migrations