### PR TITLE
fix:new elements are not being rendered

### DIFF
--- a/components/mail/mail-list.tsx
+++ b/components/mail/mail-list.tsx
@@ -321,11 +321,12 @@ export function MailList({ items: initialItems, isCompact, folder }: MailListPro
           const item = items[virtualRow.index];
           return (
             <div
-              key={item.id}
+              key={virtualRow.key}
               data-index={virtualRow.index}
               ref={virtualizer.measureElement}
               style={{
                 transform: `translateY(${virtualRow.start}px)`,
+                height: `${virtualRow.size}px`,
               }}
               className="absolute left-0 top-0 w-full p-[8px]"
             >

--- a/components/ui/scroll-area.tsx
+++ b/components/ui/scroll-area.tsx
@@ -9,12 +9,8 @@ const ScrollArea = React.forwardRef<
   React.ElementRef<typeof ScrollAreaPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
-  <ScrollAreaPrimitive.Root
-    ref={ref}
-    className={cn("relative overflow-hidden", className)}
-    {...props}
-  >
-    <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+  <ScrollAreaPrimitive.Root className={cn("relative overflow-hidden", className)} {...props}>
+    <ScrollAreaPrimitive.Viewport ref={ref} className="h-full w-full rounded-[inherit]">
       {children}
     </ScrollAreaPrimitive.Viewport>
     <ScrollBar />


### PR DESCRIPTION
## Description

Basically radix-ui's ScrollArea primitives return a distinct type of scrollTop compared to regular div -> overflow-auto. 
hence when tanstack virtual tried to calculate the length(height) of current scroll, It failed to update, there by did not update (render) new items in the dom. 

Fix: the ref was moved to ScrollAreaPrimitive.Vieweport from ScrollAreaPrimitive.Root which returns required scrollTop

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)


## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] All tests pass locally

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings

https://github.com/user-attachments/assets/c3d478d6-c5cc-4763-8510-c33354aeb7ba

Notice, the data-index of email threads are virtualized, meaning only the emails in the viewport are being rendered/added in the DOM

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
