### PR TITLE
refactor: useThreads and commented out react-virtualizer 

### DIFF
--- a/apps/mail/hooks/use-threads.ts
+++ b/apps/mail/hooks/use-threads.ts
@@ -2,11 +2,11 @@
 
 "use client";
 
-import { getMail, getMails } from "@/actions/mail";
 import { InitialThread, ParsedMessage } from "@/types";
+import { getMail, getMails } from "@/actions/mail";
 import { useSession } from "@/lib/auth-client";
+import useSWRInfinite from "swr/infinite";
 import useSWR, { preload } from "swr";
-import useSWRInfinite from 'swr/infinite'
 import { useMemo } from "react";
 
 export const preloadThread = (userId: string, threadId: string, connectionId: string) => {
@@ -14,13 +14,24 @@ export const preloadThread = (userId: string, threadId: string, connectionId: st
   preload([userId, threadId, connectionId], fetchThread);
 };
 
+type FetchEmailsTuple = [
+  folder: string,
+  q?: string,
+  max?: number,
+  labelIds?: string[],
+  pageToken?: string,
+];
+
 // TODO: improve the filters
-const fetchEmails = async (args: any[]) => {
-  const [_, folder, query, max, labelIds, pageToken] = args;
-
-  const data = await getMails({ folder, q: query, max, labelIds, pageToken });
-
-  return data;
+const fetchEmails = async ([
+  folder,
+  q,
+  max,
+  labelIds,
+  pageToken,
+]: FetchEmailsTuple): Promise<RawResponse> => {
+  const data = await getMails({ folder, q, max, labelIds, pageToken });
+  return data as RawResponse;
 };
 
 const fetchThread = async (args: any[]) => {
@@ -39,55 +50,37 @@ interface RawResponse {
 const getKey = (
   pageIndex: number,
   previousPageData: RawResponse | null,
-  userId: string,
-  folder: string,
-  query?: string,
-  max?: number,
-  labelIds?: string[],
-  connectionId?: string
-) => {
-  // reached the end
-  if (previousPageData && !previousPageData.nextPageToken) return null;
+  [folder, query, max, labelIds]: FetchEmailsTuple,
+): FetchEmailsTuple | null => {
+  if (previousPageData && !previousPageData.nextPageToken) return null; // reached the end
 
-  // first page, we don't have previousPageData
-  if (pageIndex === 0) {
-    return [userId, folder, query, max, labelIds, undefined, connectionId];
-  }
-
-  // add the pageToken to the API endpoint
-  return [userId, folder, query, max, labelIds, previousPageData?.nextPageToken, connectionId];
+  return [folder, query, max, labelIds, previousPageData?.nextPageToken];
 };
 
-export const useThreads = (
-  folder: string,
-  labelIds?: string[],
-  query?: string,
-  max?: number,
-) => {
+export const useThreads = (folder: string, labelIds?: string[], query?: string, max?: number) => {
   const { data: session } = useSession();
 
-  const { data, error, size, setSize, isLoading, isValidating, mutate } = useSWRInfinite<RawResponse>(
-    (pageIndex, previousPageData) =>
-      session?.user.id 
-        ? getKey(
-          pageIndex,
-          previousPageData,
-          session.user.id,
-          folder,
-          query,
-          max,
-          labelIds,
-          session.connectionId ?? undefined
-        )
-        : null,
-    fetchEmails as any,
-    { revalidateAll: true, revalidateOnMount: true, parallel: true }
+  const { data, size, setSize, isLoading, isValidating, error, mutate } = useSWRInfinite(
+    (pageIndex, previousPageData) => {
+      if (!session?.user.id) return null;
+      return getKey(pageIndex, previousPageData, [folder, query, max, labelIds]);
+    },
+    fetchEmails,
+    {
+      persistSize: false,
+      parallel: true,
+      revalidateAll: true,
+      revalidateOnMount: true,
+    },
   );
 
-  const threads = data ? data.flatMap(page => page.threads) : [];
+  const threads = data ? data.flatMap((e) => e.threads) : [];
   const isEmpty = data?.[0]?.threads.length === 0;
   const isReachingEnd = isEmpty || (data && !data[data.length - 1]?.nextPageToken);
-  const loadMore = () => setSize(size + 1);
+  const loadMore = () => {
+    if (isLoading || isValidating) return;
+    setSize(size + 1);
+  };
 
   return {
     data: {
@@ -99,7 +92,7 @@ export const useThreads = (
     error,
     loadMore,
     isReachingEnd,
-    mutate
+    mutate,
   };
 };
 
@@ -111,7 +104,7 @@ export const useThread = (id: string) => {
     fetchThread as any,
   );
 
-  const hasUnread = useMemo(() => data?.some(e => e.unread), [data]);
+  const hasUnread = useMemo(() => data?.some((e) => e.unread), [data]);
 
   return { data, isLoading, error, hasUnread, mutate };
 };

--- a/apps/mail/hooks/use-threads.ts
+++ b/apps/mail/hooks/use-threads.ts
@@ -68,7 +68,8 @@ export const useThreads = (folder: string, labelIds?: string[], query?: string, 
     fetchEmails,
     {
       persistSize: false,
-      parallel: true,
+      // TODO: check why parallel is fetching the same page (making duplicate requests, so same thread output)
+      // parallel: true,
       revalidateAll: true,
       revalidateOnMount: true,
     },


### PR DESCRIPTION
## Description

Refactored `useThreads` for better maintainability.

fix: Commented out "parallel" fetching option for `useSWRInfinite` calls since it was weirdly making fetches on the same page, resulting in duplicate threads.

Temporarily commented out Tanstack Virtualizer on the `mail-list.tsx` file since it had significant performance impact, can easily roll this back since it is just commented out if it is better left in regardless of the issues (my changes do make it worst if rolled back though)

And some other minor changes such as wrapping `Thread` component in memo and prettier formatting

Overall these changes provide better performance on smaller numbers of threads displayed and mainly fixes the "duplicate threads fetched issue".
On a larger number of threads displayed it might get a lot slower, one of the fixes would be to bring back Tanstack Virtualizer and fix the rerendering issues to have good performance, or else it would be to change the infinite scroll to a pagination system instead.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 💥 Breaking change (fix or feature with breaking changes) - kinda since i removed the tanstack virtualizer part?
- [x] 🎨 UI/UX improvement
- [x] ⚡ Performance improvement - (temporarily)

## Areas Affected

Please check all that apply:

- [x] User Interface/Experience
- [x] Development Workflow

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed
- [x] react-scan (?)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
