### PR TITLE
docs: Zero black-icon in light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-<div style="text-align: center;">
-<picture>
-  <source srcset="apps/mail/public/white-icon.svg" media="(prefers-color-scheme: dark)">
-  <img src="apps/mail/public/black-icon.svg" alt="Zero Logo" width="64" style="background-color: #000; padding: 10px;"/>
-</picture>
-</div>
+<p align="center">
+  <picture>
+    <source srcset="apps/mail/public/white-icon.svg" media="(prefers-color-scheme: dark)">
+    <img src="apps/mail/public/black-icon.svg" alt="Zero Logo" width="64" style="background-color: #000; padding: 10px;"/>
+  </picture>
+</p>
 
 # Zero
 


### PR DESCRIPTION
## Description

Update the README to use a dark icon for light mode, as the previous logo was not visible in light mode.

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 📝 Documentation update
- [x] 🎨 UI/UX improvement

## Areas Affected

Please check all that apply:

- [x] User Interface/Experience
- [x] Documentation

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed
- [x] Cross-browser testing (if UI changes)
- [x] Mobile responsiveness verified (if UI changes)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] I have updated the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [x] Any dependent changes are merged and published

## Screenshot

![image](https://github.com/user-attachments/assets/21f131ff-06cf-49c6-802f-f3b64c59c673)

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated the logo display in the documentation to automatically adapt to users’ color scheme preferences, ensuring optimal visibility in both dark and light modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->