### PR TITLE
fix: remove margin of the Send Invite button

### DIFF
--- a/apps/mail/components/golden.tsx
+++ b/apps/mail/components/golden.tsx
@@ -99,11 +99,11 @@ export const GoldenTicketModal = () => {
               )}
             />
             <div className="pt-3 flex gap-2 justify-end">
-              <Button onClick={handleMaybeLater} type="button" variant="outline" className="">
+              <Button onClick={handleMaybeLater} type="button" variant="outline">
                 Maybe Later
               </Button>
-              <Button disabled={!email} type="submit" className="">
-                <span className="mr-2">Send invite</span>
+              <Button disabled={!email} type="submit">
+                Send invite
               </Button>
             </div>
           </Form>


### PR DESCRIPTION
## Description

- Removed unnecessary margin to the right of the "Send invite" button text.

---

## Type of Change

Please delete options that are not relevant.

- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code


## Screenshots/Recordings

**Before**

![CleanShot 2025-04-17 at 22 46 06@2x](https://github.com/user-attachments/assets/ef9143a4-2b97-4050-93fd-467bf2d4aa3e)


**After**

![CleanShot 2025-04-17 at 22 45 24@2x](https://github.com/user-attachments/assets/5c340eac-f63b-4107-af1d-91b80c8c3fd2)


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._
