### PR TITLE
optional-force-google-auth

### DIFF
--- a/apps/server/src/lib/auth-providers.ts
+++ b/apps/server/src/lib/auth-providers.ts
@@ -36,6 +36,7 @@ export const authProviders = (env: Record<string, string>): ProviderConfig[] => 
       { name: 'GOOGLE_CLIENT_SECRET', source: 'Google Cloud Console' },
     ],
     config: {
+      prompt: env.FORCE_GOOGLE_AUTH ? 'consent' : undefined,
       accessType: 'offline',
       scope: [
         'https://www.googleapis.com/auth/gmail.modify',


### PR DESCRIPTION
## Description

Added support for forcing Google OAuth consent screen by introducing a new environment variable `FORCE_GOOGLE_AUTH`. When this variable is set, the Google authentication provider will use the `consent` prompt parameter, which forces the Google consent screen to appear even if the user has previously authorized the application.

This change is useful for testing scenarios and for cases where users need to re-authorize with different scopes.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Areas Affected

- [x] Authentication/Authorization
- [x] Email Integration (Gmail, IMAP, etc.)

## Testing Done

- [x] Manual testing performed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

This is a non-breaking change as it only adds optional functionality that is disabled by default. The Google authentication flow will behave exactly as before unless the new environment variable is explicitly set.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._