### PR TITLE
prevent loading flash when saving draft

### DIFF
--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -71,8 +71,18 @@ export function CreateEmail({
   const [isComposeOpen, setIsComposeOpen] = useQueryState('isComposeOpen');
   const { data: activeConnection } = useActiveConnection();
   const { data: settings, isLoading: settingsLoading } = useSettings();
-  const isInternallySavingDraft = sessionStorage.getItem('isInternallySavingDraft') === 'true';
+  const [isInternallySavingDraft, setIsInternallySavingDraft] = useState(false);
   const showLoadingState = isDraftLoading && !isInternallySavingDraft && !draft;
+
+  useEffect(() => {
+    try {
+      const flag = sessionStorage.getItem('isInternallySavingDraft') === 'true';
+      setIsInternallySavingDraft(flag);
+    } catch (error) {
+      console.warn('Failed to read sessionStorage flag:', error);
+      setIsInternallySavingDraft(false);
+    }
+  }, []);
 
   // If there was an error loading the draft, set the failed state
   useEffect(() => {


### PR DESCRIPTION
### TL;DR

Fixed loading state flicker when saving drafts in the email composer.

### What changed?

- Added a mechanism to track when drafts are being internally saved using `sessionStorage`
- Created a new `isInternallySavingDraft` state to prevent showing loading states during internal draft operations
- Modified the loading state logic in `create-email.tsx` to only show when truly loading a draft from the server
- Added cleanup timeouts to ensure the internal saving state is properly reset

### How to test?

1. Open the email composer
2. Type some content in the email
3. Verify that the loading spinner doesn't appear when the draft is automatically saved
4. Navigate away and back to the draft to confirm it loads properly
5. Verify that the loading spinner only appears when loading a draft from the server

### Why make this change?

Previously, the email composer would show a loading spinner whenever the draft ID was updated, even during internal operations like auto-saving. This created a poor user experience with unnecessary flickering of the UI. This change ensures the loading state is only shown when actually fetching data from the server, providing a smoother experience when composing emails.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved the handling of draft saving to prevent unnecessary loading spinners and avoid unwanted state changes during internal draft save operations.
- **New Features**
	- Enhanced draft save logic to provide a smoother and more accurate user experience when composing emails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->