### PR TITLE
Add email actions to AI router

### DIFF
--- a/apps/server/src/services/mcp-service/mcp.ts
+++ b/apps/server/src/services/mcp-service/mcp.ts
@@ -9,7 +9,7 @@ import { createDb } from '../../db';
 import { generateText } from 'ai';
 import { z } from 'zod';
 
-const getDriverFromConnectionId = async (connectionId: string) => {
+export const getDriverFromConnectionId = async (connectionId: string) => {
   const db = createDb(env.HYPERDRIVE.connectionString);
   const activeConnection = await db.query.connection.findFirst({
     where: (connection, ops) => ops.eq(connection.id, connectionId),

--- a/apps/server/wrangler.jsonc
+++ b/apps/server/wrangler.jsonc
@@ -67,6 +67,7 @@
         "VITE_PUBLIC_BACKEND_URL": "http://localhost:8787",
         "VITE_PUBLIC_APP_URL": "http://localhost:3000",
         "JWT_SECRET": "secret",
+        "ELEVENLABS_API_KEY": "1234567890",
       },
       "kv_namespaces": [
         {


### PR DESCRIPTION
# Implement AI Email Actions API Endpoint

## Description

This PR adds a new `/do/:action` endpoint to the AI router that enables email-related functionality through the MCP service. The endpoint supports three main actions:
- Listing email threads from the inbox
- Composing new emails with AI assistance
- Sending emails to recipients

Additionally, it exports the `getDriverFromConnectionId` function from the MCP service to make it accessible to the new endpoint and adds the required ElevenLabs API key to the environment variables.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] API Endpoints

## Testing Done

- [x] Manual testing performed

## Security Considerations

- [x] No sensitive data is exposed
- [x] Authentication checks are in place (via X-Connection-Id header)
- [x] Input validation is implemented

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The new endpoint requires a valid connection ID in the X-Connection-Id header for authentication. It returns appropriate error responses when the connection ID is missing or invalid.