### PR TITLE
fixes to use correct reply to address

### DIFF
--- a/apps/mail/components/create/email-composer.tsx
+++ b/apps/mail/components/create/email-composer.tsx
@@ -188,7 +188,7 @@ export function EmailComposer({
 
     const userEmail = activeConnection.email.toLowerCase();
     const latestEmail = emailData.latest;
-    const senderEmail = latestEmail.sender.email.toLowerCase();
+    const senderEmail = latestEmail.replyTo;
 
     // Reset states
     form.reset();
@@ -213,7 +213,7 @@ export function EmailComposer({
 
       // Add original sender if not current user
       if (senderEmail !== userEmail) {
-        to.push(latestEmail.sender.email);
+        to.push(latestEmail.replyTo || latestEmail.sender.email);
       }
 
       // Add original recipients from To field
@@ -385,6 +385,8 @@ export function EmailComposer({
         message: editor.getHTML(),
         attachments: await serializeFiles(values.attachments ?? []),
         id: draftId,
+        threadId: threadId ? threadId : null,
+        fromEmail: values.fromEmail ? values.fromEmail : null,
       };
 
       const response = await createDraft(draftData);

--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -1491,32 +1491,42 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                     {t('common.mailDisplay.from')}:
                                   </span>
                                   <div className="ml-3">
-                                    <span className="text-muted-foreground pr-1 font-bold">
+                                    <span className="text-muted-foreground text-nowrap pr-1 font-bold">
                                       {cleanNameDisplay(emailData?.sender?.name)}
                                     </span>
                                     {emailData?.sender?.name !== emailData?.sender?.email && (
-                                      <span className="text-muted-foreground">
+                                      <span className="text-muted-foreground text-nowrap">
                                         {cleanEmailDisplay(emailData?.sender?.email)}
                                       </span>
                                     )}
                                   </div>
                                 </div>
                                 <div className="flex">
-                                  <span className="w-24 text-end text-gray-500">
+                                  <span className="w-24 text-nowrap text-end text-gray-500">
                                     {t('common.mailDisplay.to')}:
                                   </span>
-                                  <span className="text-muted-foreground ml-3">
+                                  <span className="text-muted-foreground ml-3 text-nowrap">
                                     {emailData?.to
                                       ?.map((t) => cleanEmailDisplay(t.email))
                                       .join(', ')}
                                   </span>
                                 </div>
+                                {emailData?.replyTo && emailData.replyTo.length > 0 && (
+                                  <div className="flex">
+                                    <span className="w-24 text-nowrap text-end text-gray-500">
+                                      {t('common.mailDisplay.replyTo')}:
+                                    </span>
+                                    <span className="text-muted-foreground ml-3 text-nowrap">
+                                      {cleanEmailDisplay(emailData?.replyTo)}
+                                    </span>
+                                  </div>
+                                )}
                                 {emailData?.cc && emailData.cc.length > 0 && (
                                   <div className="flex">
-                                    <span className="w-24 text-end text-gray-500">
+                                    <span className="shrink-0text-nowrap w-24 text-end text-gray-500">
                                       {t('common.mailDisplay.cc')}:
                                     </span>
-                                    <span className="text-muted-foreground ml-3">
+                                    <span className="text-muted-foreground ml-3 text-nowrap">
                                       {emailData?.cc
                                         ?.map((t) => cleanEmailDisplay(t.email))
                                         .join(', ')}
@@ -1528,7 +1538,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                     <span className="w-24 text-end text-gray-500">
                                       {t('common.mailDisplay.bcc')}:
                                     </span>
-                                    <span className="text-muted-foreground ml-3">
+                                    <span className="text-muted-foreground ml-3 text-nowrap">
                                       {emailData?.bcc
                                         ?.map((t) => cleanEmailDisplay(t.email))
                                         .join(', ')}
@@ -1539,7 +1549,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                   <span className="w-24 text-end text-gray-500">
                                     {t('common.mailDisplay.date')}:
                                   </span>
-                                  <span className="text-muted-foreground ml-3">
+                                  <span className="text-muted-foreground ml-3 text-nowrap">
                                     {emailData?.receivedOn &&
                                     !isNaN(new Date(emailData.receivedOn).getTime())
                                       ? format(new Date(emailData.receivedOn), 'PPpp')
@@ -1550,7 +1560,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                   <span className="w-24 text-end text-gray-500">
                                     {t('common.mailDisplay.mailedBy')}:
                                   </span>
-                                  <span className="text-muted-foreground ml-3">
+                                  <span className="text-muted-foreground ml-3 text-nowrap">
                                     {cleanEmailDisplay(emailData?.sender?.email)}
                                   </span>
                                 </div>
@@ -1558,7 +1568,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                                   <span className="w-24 text-end text-gray-500">
                                     {t('common.mailDisplay.signedBy')}:
                                   </span>
-                                  <span className="text-muted-foreground ml-3">
+                                  <span className="text-muted-foreground ml-3 text-nowrap">
                                     {cleanEmailDisplay(emailData?.sender?.email)}
                                   </span>
                                 </div>

--- a/apps/mail/locales/en.json
+++ b/apps/mail/locales/en.json
@@ -169,6 +169,7 @@
       "details": "Details",
       "from": "From",
       "to": "To",
+      "replyTo": "Reply To",
       "cc": "Cc",
       "bcc": "Bcc",
       "date": "Date",
@@ -494,8 +495,6 @@
           "bulkSelect": "Bulk select",
           "bulkArchive": "Bulk archive",
           "bulkStar": "Bulk star"
-
-          
         }
       },
       "labels": {

--- a/apps/server/src/lib/driver/google.ts
+++ b/apps/server/src/lib/driver/google.ts
@@ -369,6 +369,9 @@ export class GoogleMailManager implements MailManager {
                     attachmentId: attachmentId,
                     headers: part.headers || [],
                     body: attachmentData ?? '',
+                    replyTo: message.payload?.headers?.find(
+                      (h) => h.name?.toLowerCase() === 'reply-to',
+                    )?.value,
                   };
                 } catch {
                   return null;
@@ -602,6 +605,7 @@ export class GoogleMailManager implements MailManager {
         const requestBody = {
           message: {
             raw: encodedMessage,
+            threadId: data.threadId,
           },
         };
 


### PR DESCRIPTION
# Add Reply-To Support and Improve Email Composer

## Description

This PR adds support for Reply-To email headers in the mail application. It updates the email composer to properly handle Reply-To addresses when replying to emails, and displays the Reply-To field in the email details view. Additionally, it improves the email composer by adding thread ID and from email support when creating drafts, and enhances the UI with better text wrapping for email headers.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added display of the "Reply-To" field in the email details popover, allowing users to see the designated reply address when present.

- **Improvements**
	- Enhanced email details layout for better readability by preventing line breaks in address and label fields.
	- Draft emails now save additional information, including the thread ID and sender email, for improved draft management.
	- Reply and Reply All modes now better handle the sender's reply-to address to ensure accurate recipient lists.

- **Localization**
	- Added a new label for "Reply To" in the mail display interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->