### PR TITLE
fixed email composer bottom pannel breaking issue if email content gr…

### DIFF
--- a/apps/mail/components/create/email-composer.tsx
+++ b/apps/mail/components/create/email-composer.tsx
@@ -459,7 +459,7 @@ export function EmailComposer({
         className,
       )}
     >
-      <div className="no-scrollbar dark:bg-panelDark max-h-[500px] grow overflow-y-auto">
+      <div className="no-scrollbar dark:bg-panelDark  grow overflow-y-auto">
         {/* To, Cc, Bcc */}
         <div className="shrink-0 overflow-y-auto border-b border-[#E7E7E7] pb-2 dark:border-[#252525]">
           <div className="flex justify-between px-3 pt-3">


### PR DESCRIPTION
<img width="1920" alt="Screenshot 2025-06-18 at 11 44 08 AM (2)" src="https://github.com/user-attachments/assets/e9f6faea-b214-42ff-a030-289b1b4d0e75" />

While composing the email both parent container and the child had max-h-[500px] which resulted in breaking the bottom bar when email content grows over 500px .
There's no need to have max height property on the children (email content container) as the body container is already taking up the remaining height
PR:
<img width="1920" alt="Screenshot 2025-06-18 at 11 43 29 AM (2)" src="https://github.com/user-attachments/assets/352f3178-5232-4df5-94a6-a346977861b4" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the email composer layout to remove the maximum height restriction, allowing the content area to expand vertically as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->