### PR TITLE
fix: subject generation when subject is empty

### DIFF
--- a/apps/mail/components/create/email-composer.tsx
+++ b/apps/mail/components/create/email-composer.tsx
@@ -1088,7 +1088,11 @@ export function EmailComposer({
               setHasUnsavedChanges(true);
             }}
           />
-          <button onClick={handleGenerateSubject} disabled={isLoading || isGeneratingSubject}>
+          <button
+            onClick={handleGenerateSubject}
+            disabled={isLoading || isGeneratingSubject || subjectInput.trim().length < 3}
+            className="disabled:opacity-50"
+          >
             <div className="flex items-center justify-center gap-2.5 pl-0.5">
               <div className="flex h-5 items-center justify-center gap-1 rounded-sm">
                 {isGeneratingSubject ? (


### PR DESCRIPTION
## Description
fix #1382 
Currently, a subject is generated even if the email body is empty.
To fix this, I have added a condition to enable the generate button only when the subject length is greater than 3.

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](../CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [x] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings
- Before:
![before](https://github.com/user-attachments/assets/3c685716-db72-40c3-942b-97b8f36426f6)
- After (if sub length is 0, button is disabled. if sub length is > 0, button is enabled):
![after](https://github.com/user-attachments/assets/c4b4135c-8ca2-43e3-89cb-4171187ca806)


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - The "Generate Subject" button in the email composer is now disabled if the subject input is less than 3 characters, preventing accidental clicks.
- **Style**
  - The disabled "Generate Subject" button now appears with reduced opacity for clearer visual feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->