### PR TITLE
Fix: Ai Chatbox fixes + Added option in shortcuts ui

### DIFF
--- a/apps/mail/components/create/ai-chat.tsx
+++ b/apps/mail/components/create/ai-chat.tsx
@@ -394,7 +394,8 @@ export function AIChat({
       </div>
 
       {/* Fixed input at bottom */}
-      <div className={cn('mb-4 flex-shrink-0 px-4', isFullScreen ? 'px-0' : '')}>
+      { chatMessages && !chatMessages.enabled ?
+      (null) : (<div className={cn('mb-4 flex-shrink-0 px-4', isFullScreen ? 'px-0' : '')}>
         <div className="bg-offsetLight relative rounded-lg p-2 dark:bg-[#202020]">
           <div className="flex flex-col">
             <div className="w-full">
@@ -503,7 +504,7 @@ export function AIChat({
           </Select>
         </div>
         </div> */}
-      </div>
+      </div>)}
     </div>
   );
 }

--- a/apps/mail/config/shortcuts.ts
+++ b/apps/mail/config/shortcuts.ts
@@ -108,6 +108,13 @@ const navigation: Shortcut[] = [
     description: 'Show keyboard shortcuts',
     scope: 'navigation',
   },
+  {
+    keys: ['mod', '0'],
+    action: 'openAIAssistant',
+    type: 'combination',
+    description: 'Open AI assistant',
+    scope: 'navigation',
+  }
 ];
 
 const globalShortcuts: Shortcut[] = [

--- a/apps/mail/locales/en.json
+++ b/apps/mail/locales/en.json
@@ -486,6 +486,7 @@
           "goToDrafts": "Go to Drafts",
           "expandEmailView": "Expand Email View",
           "helpWithShortcuts": "Help with shortcuts",
+          "openAIAssistant": "Open AI Assistant",
           "recordHotkey": "Record Hotkey",
           "pressKeys": "Press keys",
           "releaseKeys": "Release keys",


### PR DESCRIPTION
Fixes #1517 

1. Ai chat input should be disabled for free user
 https://github.com/user-attachments/assets/60ceae1b-dbcf-4f7d-a58e-f255064b91fc

2. Open AI Assistant should be in shortcuts under navigation

<img width="887" alt="Image" src="https://github.com/user-attachments/assets/be12e26e-4551-4fa6-8d31-1190210bc16f" />

---------------------

1.  Ai chat input should be disabled
<img width="565" alt="image" src="https://github.com/user-attachments/assets/4cf5c421-17b0-4f14-a402-099f00cddc18" />

2. Open AI Assistant should be in shortcuts under navigation
<img width="871" alt="image" src="https://github.com/user-attachments/assets/5b2bdf46-438f-4809-9b6e-4b333623d21f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a keyboard shortcut (mod + 0) to quickly open the AI assistant.
  * Introduced a new label for the AI assistant shortcut in the English interface.

* **Bug Fixes**
  * The input area in the AI chat is now hidden when chat messages are disabled in billing, preventing user input in that state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->