### PR TITLE
updates labels system

### DIFF
--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -17,12 +17,12 @@ import { CurvedArrow } from '@/components/icons/icons';
 import { LABEL_COLORS } from '@/lib/label-colors';
 import type { Label as LabelType } from '@/types';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
 import { useState, useEffect } from 'react';
 import { useForm } from 'react-hook-form';
-import { Command } from 'lucide-react';
 import { m } from '@/paraglide/messages';
+import { Command } from 'lucide-react';
 
 interface LabelDialogProps {
   trigger?: React.ReactNode;
@@ -64,12 +64,13 @@ export function LabelDialog({
       if (editingLabel) {
         form.reset({
           name: editingLabel.name,
-          color: editingLabel.color || { backgroundColor: '#E2E2E2', textColor: '#000000' },
+          color: editingLabel.color || { backgroundColor: '', textColor: '' },
         });
       } else {
+        // Let server assign random color for new labels
         form.reset({
           name: '',
-          color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
+          color: { backgroundColor: '', textColor: '' },
         });
       }
     }
@@ -85,7 +86,7 @@ export function LabelDialog({
     setDialogOpen(false);
     form.reset({
       name: '',
-      color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
+      color: { backgroundColor: '', textColor: '' },
     });
   };
 
@@ -94,7 +95,9 @@ export function LabelDialog({
       {trigger && <DialogTrigger asChild>{trigger}</DialogTrigger>}
       <DialogContent showOverlay={true}>
         <DialogHeader>
-          <DialogTitle>{editingLabel ? m['common.labels.editLabel']() : m['common.mail.createNewLabel']()}</DialogTitle>
+          <DialogTitle>
+            {editingLabel ? m['common.labels.editLabel']() : m['common.mail.createNewLabel']()}
+          </DialogTitle>
         </DialogHeader>
         <Form {...form}>
           <form
@@ -153,7 +156,9 @@ export function LabelDialog({
                 {m['common.actions.cancel']()}
               </Button>
               <Button className="h-8 [&_svg]:size-4" type="submit">
-                {editingLabel ? m['common.actions.saveChanges']() : m['common.labels.createLabel']()}
+                {editingLabel
+                  ? m['common.actions.saveChanges']()
+                  : m['common.labels.createLabel']()}
                 <div className="flex h-5 items-center justify-center gap-1 rounded-sm bg-white/10 px-1 dark:bg-black/10">
                   <Command className="h-3 w-3 text-white dark:text-[#929292]" />
                   <CurvedArrow className="mt-1.5 h-3.5 w-3.5 fill-white dark:fill-[#929292]" />

--- a/apps/mail/hooks/use-label-orders.ts
+++ b/apps/mail/hooks/use-label-orders.ts
@@ -1,0 +1,16 @@
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { useTRPC } from '@/providers/query-provider';
+
+export function useLabelOrders() {
+  const trpc = useTRPC();
+
+  const { data: orders } = useQuery(
+    trpc.labels.getOrders.queryOptions(void 0, {
+      staleTime: 1000 * 60 * 5, // 5 minutes
+    }),
+  );
+
+  const { mutateAsync: updateOrders } = useMutation(trpc.labels.reorder.mutationOptions());
+
+  return { orders, updateOrders };
+}

--- a/apps/mail/hooks/use-labels.ts
+++ b/apps/mail/hooks/use-labels.ts
@@ -9,6 +9,8 @@ export function useLabels() {
       staleTime: 1000 * 60 * 60, // 1 hour
     }),
   );
+
+  // Labels are already sorted by order from the server
   return labelQuery;
 }
 

--- a/apps/mail/messages/en.json
+++ b/apps/mail/messages/en.json
@@ -376,21 +376,19 @@
       "mb": "{amount} MB"
     },
     "labels": {
-      "color": "Color",
-      "labelName": "Label Name",
-      "createLabel": "Create Label",
+      "editLabel": "Edit Label",
       "deleteLabel": "Delete Label",
-      "deleteLabelConfirm": "Are you sure you want to delete this label?",
-      "deleteLabelConfirmDescription": "This action cannot be undone.",
-      "deleteLabelConfirmCancel": "Cancel",
-      "deleteLabelConfirmDelete": "Delete",
+      "savingLabel": "Saving label...",
+      "saveLabelSuccess": "Label saved successfully",
+      "failedToSavingLabel": "Failed to save label",
+      "deletingLabel": "Deleting label...",
       "deleteLabelSuccess": "Label deleted successfully",
       "failedToDeleteLabel": "Failed to delete label",
-      "deletingLabel": "Deleting label...",
-      "editLabel": "Edit Label",
-      "savingLabel": "Saving label...",
-      "failedToSavingLabel": "Failed to save label",
-      "saveLabelSuccess": "Label saved successfully"
+      "labelName": "Label Name",
+      "color": "Color",
+      "createLabel": "Create Label",
+      "labelsReordered": "Labels reordered successfully",
+      "failedToReorderLabels": "Failed to reorder labels"
     }
   },
   "navigation": {

--- a/apps/mail/types/index.ts
+++ b/apps/mail/types/index.ts
@@ -7,6 +7,7 @@ export type Label = {
   };
   type: string;
   labels?: Label[];
+  order?: number;
 };
 
 export interface User {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -57,6 +57,7 @@
     "jose": "6.0.11",
     "jsonrepair": "^3.12.0",
     "mimetext": "^3.0.27",
+    "nanoid": "5.1.5",
     "p-retry": "6.2.1",
     "partyserver": "^0.0.71",
     "postgres": "3.4.5",

--- a/apps/server/src/db/migrations/0035_shocking_green_goblin.sql
+++ b/apps/server/src/db/migrations/0035_shocking_green_goblin.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "mail0_label_order" (
+	"id" text PRIMARY KEY NOT NULL,
+	"connection_id" text NOT NULL,
+	"label_id" text NOT NULL,
+	"order" integer DEFAULT 999999 NOT NULL,
+	"custom_color" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "mail0_label_order_connection_id_label_id_unique" UNIQUE("connection_id","label_id")
+);
+--> statement-breakpoint
+ALTER TABLE "mail0_label_order" ADD CONSTRAINT "mail0_label_order_connection_id_mail0_connection_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."mail0_connection"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/server/src/db/migrations/0036_bizarre_bushwacker.sql
+++ b/apps/server/src/db/migrations/0036_bizarre_bushwacker.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "mail0_label_order" (
+	"id" text PRIMARY KEY NOT NULL,
+	"connection_id" text NOT NULL,
+	"label_id" text NOT NULL,
+	"order" integer DEFAULT 999999 NOT NULL,
+	"custom_color" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "mail0_label_order_connection_id_label_id_unique" UNIQUE("connection_id","label_id")
+);
+--> statement-breakpoint
+ALTER TABLE "mail0_label_order" ADD CONSTRAINT "mail0_label_order_connection_id_mail0_connection_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."mail0_connection"("id") ON DELETE cascade ON UPDATE no action;

--- a/apps/server/src/db/migrations/0037_dazzling_queen_noir.sql
+++ b/apps/server/src/db/migrations/0037_dazzling_queen_noir.sql
@@ -1,0 +1,58 @@
+CREATE TABLE "mail0_label_order" (
+	"id" text PRIMARY KEY NOT NULL,
+	"connection_id" text NOT NULL,
+	"label_id" text NOT NULL,
+	"order" integer DEFAULT 999999 NOT NULL,
+	"custom_color" jsonb,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"updated_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "mail0_label_order_connection_id_label_id_unique" UNIQUE("connection_id","label_id")
+);
+--> statement-breakpoint
+ALTER TABLE "mail0_account" DROP CONSTRAINT "mail0_account_user_id_mail0_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "mail0_connection" DROP CONSTRAINT "mail0_connection_user_id_mail0_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "mail0_session" DROP CONSTRAINT "mail0_session_user_id_mail0_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "mail0_user_hotkeys" DROP CONSTRAINT "mail0_user_hotkeys_user_id_mail0_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "mail0_user_settings" DROP CONSTRAINT "mail0_user_settings_user_id_mail0_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "mail0_label_order" ADD CONSTRAINT "mail0_label_order_connection_id_mail0_connection_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."mail0_connection"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail0_account" ADD CONSTRAINT "mail0_account_user_id_mail0_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."mail0_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail0_connection" ADD CONSTRAINT "mail0_connection_user_id_mail0_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."mail0_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail0_session" ADD CONSTRAINT "mail0_session_user_id_mail0_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."mail0_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail0_summary" ADD CONSTRAINT "mail0_summary_connection_id_mail0_connection_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."mail0_connection"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail0_user_hotkeys" ADD CONSTRAINT "mail0_user_hotkeys_user_id_mail0_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."mail0_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "mail0_user_settings" ADD CONSTRAINT "mail0_user_settings_user_id_mail0_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."mail0_user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "account_user_id_idx" ON "mail0_account" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "account_provider_user_id_idx" ON "mail0_account" USING btree ("provider_id","user_id");--> statement-breakpoint
+CREATE INDEX "account_expires_at_idx" ON "mail0_account" USING btree ("access_token_expires_at");--> statement-breakpoint
+CREATE INDEX "connection_user_id_idx" ON "mail0_connection" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "connection_expires_at_idx" ON "mail0_connection" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "connection_provider_id_idx" ON "mail0_connection" USING btree ("provider_id");--> statement-breakpoint
+CREATE INDEX "early_access_is_early_access_idx" ON "mail0_early_access" USING btree ("is_early_access");--> statement-breakpoint
+CREATE INDEX "jwks_created_at_idx" ON "mail0_jwks" USING btree ("created_at");--> statement-breakpoint
+CREATE INDEX "note_user_id_idx" ON "mail0_note" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "note_thread_id_idx" ON "mail0_note" USING btree ("thread_id");--> statement-breakpoint
+CREATE INDEX "note_user_thread_idx" ON "mail0_note" USING btree ("user_id","thread_id");--> statement-breakpoint
+CREATE INDEX "note_is_pinned_idx" ON "mail0_note" USING btree ("is_pinned");--> statement-breakpoint
+CREATE INDEX "oauth_access_token_user_id_idx" ON "mail0_oauth_access_token" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_access_token_client_id_idx" ON "mail0_oauth_access_token" USING btree ("client_id");--> statement-breakpoint
+CREATE INDEX "oauth_access_token_expires_at_idx" ON "mail0_oauth_access_token" USING btree ("access_token_expires_at");--> statement-breakpoint
+CREATE INDEX "oauth_application_user_id_idx" ON "mail0_oauth_application" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_application_disabled_idx" ON "mail0_oauth_application" USING btree ("disabled");--> statement-breakpoint
+CREATE INDEX "oauth_consent_user_id_idx" ON "mail0_oauth_consent" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "oauth_consent_client_id_idx" ON "mail0_oauth_consent" USING btree ("client_id");--> statement-breakpoint
+CREATE INDEX "oauth_consent_given_idx" ON "mail0_oauth_consent" USING btree ("consent_given");--> statement-breakpoint
+CREATE INDEX "session_user_id_idx" ON "mail0_session" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "session_expires_at_idx" ON "mail0_session" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "summary_connection_id_idx" ON "mail0_summary" USING btree ("connection_id");--> statement-breakpoint
+CREATE INDEX "summary_connection_id_saved_idx" ON "mail0_summary" USING btree ("connection_id","saved");--> statement-breakpoint
+CREATE INDEX "summary_saved_idx" ON "mail0_summary" USING btree ("saved");--> statement-breakpoint
+CREATE INDEX "user_hotkeys_shortcuts_idx" ON "mail0_user_hotkeys" USING btree ("shortcuts");--> statement-breakpoint
+CREATE INDEX "user_settings_settings_idx" ON "mail0_user_settings" USING btree ("settings");--> statement-breakpoint
+CREATE INDEX "verification_identifier_idx" ON "mail0_verification" USING btree ("identifier");--> statement-breakpoint
+CREATE INDEX "verification_expires_at_idx" ON "mail0_verification" USING btree ("expires_at");--> statement-breakpoint
+CREATE INDEX "writing_style_matrix_style_idx" ON "mail0_writing_style_matrix" USING btree ("style");

--- a/apps/server/src/db/migrations/meta/0036_snapshot.json
+++ b/apps/server/src/db/migrations/meta/0036_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "0b7459fd-f13f-4111-b30a-f0bd16a5b406",
-  "prevId": "185ab778-1f86-44d6-ac1a-90e9399b1342",
+  "id": "bab982e5-4545-4c34-a88e-7e5b275844ce",
+  "prevId": "0b7459fd-f13f-4111-b30a-f0bd16a5b406",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -145,8 +145,12 @@
           "name": "mail0_account_user_id_mail0_user_id_fk",
           "tableFrom": "mail0_account",
           "tableTo": "mail0_user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -286,8 +290,12 @@
           "name": "mail0_connection_user_id_mail0_user_id_fk",
           "tableFrom": "mail0_connection",
           "tableTo": "mail0_user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -297,7 +305,10 @@
         "mail0_connection_user_id_email_unique": {
           "name": "mail0_connection_user_id_email_unique",
           "nullsNotDistinct": false,
-          "columns": ["user_id", "email"]
+          "columns": [
+            "user_id",
+            "email"
+          ]
         }
       },
       "policies": {},
@@ -370,7 +381,9 @@
         "mail0_early_access_email_unique": {
           "name": "mail0_early_access_email_unique",
           "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": [
+            "email"
+          ]
         }
       },
       "policies": {},
@@ -426,6 +439,87 @@
       "foreignKeys": {},
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mail0_label_order": {
+      "name": "mail0_label_order",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "label_id": {
+          "name": "label_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 999999
+        },
+        "custom_color": {
+          "name": "custom_color",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "mail0_label_order_connection_id_mail0_connection_id_fk": {
+          "name": "mail0_label_order_connection_id_mail0_connection_id_fk",
+          "tableFrom": "mail0_label_order",
+          "tableTo": "mail0_connection",
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "mail0_label_order_connection_id_label_id_unique": {
+          "name": "mail0_label_order_connection_id_label_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "connection_id",
+            "label_id"
+          ]
+        }
+      },
       "policies": {},
       "checkConstraints": {},
       "isRLSEnabled": false
@@ -567,8 +661,12 @@
           "name": "mail0_note_user_id_mail0_user_id_fk",
           "tableFrom": "mail0_note",
           "tableTo": "mail0_user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -697,12 +795,16 @@
         "mail0_oauth_access_token_access_token_unique": {
           "name": "mail0_oauth_access_token_access_token_unique",
           "nullsNotDistinct": false,
-          "columns": ["access_token"]
+          "columns": [
+            "access_token"
+          ]
         },
         "mail0_oauth_access_token_refresh_token_unique": {
           "name": "mail0_oauth_access_token_refresh_token_unique",
           "nullsNotDistinct": false,
-          "columns": ["refresh_token"]
+          "columns": [
+            "refresh_token"
+          ]
         }
       },
       "policies": {},
@@ -824,7 +926,9 @@
         "mail0_oauth_application_client_id_unique": {
           "name": "mail0_oauth_application_client_id_unique",
           "nullsNotDistinct": false,
-          "columns": ["client_id"]
+          "columns": [
+            "client_id"
+          ]
         }
       },
       "policies": {},
@@ -1022,8 +1126,12 @@
           "name": "mail0_session_user_id_mail0_user_id_fk",
           "tableFrom": "mail0_session",
           "tableTo": "mail0_user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1033,7 +1141,9 @@
         "mail0_session_token_unique": {
           "name": "mail0_session_token_unique",
           "nullsNotDistinct": false,
-          "columns": ["token"]
+          "columns": [
+            "token"
+          ]
         }
       },
       "policies": {},
@@ -1152,8 +1262,12 @@
           "name": "mail0_summary_connection_id_mail0_connection_id_fk",
           "tableFrom": "mail0_summary",
           "tableTo": "mail0_connection",
-          "columnsFrom": ["connection_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "connection_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1242,12 +1356,16 @@
         "mail0_user_email_unique": {
           "name": "mail0_user_email_unique",
           "nullsNotDistinct": false,
-          "columns": ["email"]
+          "columns": [
+            "email"
+          ]
         },
         "mail0_user_phone_number_unique": {
           "name": "mail0_user_phone_number_unique",
           "nullsNotDistinct": false,
-          "columns": ["phone_number"]
+          "columns": [
+            "phone_number"
+          ]
         }
       },
       "policies": {},
@@ -1305,8 +1423,12 @@
           "name": "mail0_user_hotkeys_user_id_mail0_user_id_fk",
           "tableFrom": "mail0_user_hotkeys",
           "tableTo": "mail0_user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1375,8 +1497,12 @@
           "name": "mail0_user_settings_user_id_mail0_user_id_fk",
           "tableFrom": "mail0_user_settings",
           "tableTo": "mail0_user",
-          "columnsFrom": ["user_id"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1386,7 +1512,9 @@
         "mail0_user_settings_user_id_unique": {
           "name": "mail0_user_settings_user_id_unique",
           "nullsNotDistinct": false,
-          "columns": ["user_id"]
+          "columns": [
+            "user_id"
+          ]
         }
       },
       "policies": {},
@@ -1525,8 +1653,12 @@
           "name": "mail0_writing_style_matrix_connectionId_mail0_connection_id_fk",
           "tableFrom": "mail0_writing_style_matrix",
           "tableTo": "mail0_connection",
-          "columnsFrom": ["connectionId"],
-          "columnsTo": ["id"],
+          "columnsFrom": [
+            "connectionId"
+          ],
+          "columnsTo": [
+            "id"
+          ],
           "onDelete": "cascade",
           "onUpdate": "no action"
         }
@@ -1534,7 +1666,9 @@
       "compositePrimaryKeys": {
         "mail0_writing_style_matrix_connectionId_pk": {
           "name": "mail0_writing_style_matrix_connectionId_pk",
-          "columns": ["connectionId"]
+          "columns": [
+            "connectionId"
+          ]
         }
       },
       "uniqueConstraints": {},

--- a/apps/server/src/db/migrations/meta/_journal.json
+++ b/apps/server/src/db/migrations/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1751568728663,
       "tag": "0035_uneven_shiva",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1751662986622,
+      "tag": "0036_bizarre_bushwacker",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -297,3 +297,25 @@ export const oauthConsent = createTable(
     index('oauth_consent_given_idx').on(t.consentGiven),
   ],
 );
+
+export const labelOrder = createTable(
+  'label_order',
+  {
+    id: text('id').primaryKey(),
+    connectionId: text('connection_id')
+      .notNull()
+      .references(() => connection.id, { onDelete: 'cascade' }),
+    labelId: text('label_id').notNull(),
+    order: integer('order').notNull().default(999999),
+    customColor: jsonb('custom_color').$type<{
+      backgroundColor: string;
+      textColor: string;
+    }>(),
+    createdAt: timestamp('created_at').notNull().defaultNow(),
+    updatedAt: timestamp('updated_at')
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (table) => [unique().on(table.connectionId, table.labelId)],
+);

--- a/apps/server/src/trpc/routes/label.ts
+++ b/apps/server/src/trpc/routes/label.ts
@@ -1,7 +1,21 @@
 import { activeDriverProcedure, createRateLimiterMiddleware, router } from '../trpc';
 import { getZeroAgent } from '../../lib/server-utils';
 import { Ratelimit } from '@upstash/ratelimit';
+import { labelOrder } from '../../db/schema';
+import { env } from 'cloudflare:workers';
+import { eq, sql } from 'drizzle-orm';
+import { createDb } from '../../db';
+import { nanoid } from 'nanoid';
 import { z } from 'zod';
+
+const LABEL_COLORS = [
+  { textColor: '#FFFFFF', backgroundColor: '#202020' },
+  { textColor: '#D1F0D9', backgroundColor: '#12341D' },
+  { textColor: '#FDECCE', backgroundColor: '#413111' },
+  { textColor: '#FDD9DF', backgroundColor: '#411D23' },
+  { textColor: '#D8E6FD', backgroundColor: '#1C2A41' },
+  { textColor: '#E8DEFD', backgroundColor: '#2C2341' },
+];
 
 export const labelsRouter = router({
   list: activeDriverProcedure
@@ -23,13 +37,28 @@ export const labelsRouter = router({
             })
             .optional(),
           type: z.string(),
+          order: z.number().optional(),
         }),
       ),
     )
     .query(async ({ ctx }) => {
       const { activeConnection } = ctx;
       const agent = await getZeroAgent(activeConnection.id);
-      return await agent.getUserLabels();
+      const labels = await agent.getUserLabels();
+
+      const labelOrders = await agent.getLabelOrders();
+
+      const orderMap = new Map(
+        labelOrders.map((lo) => [lo.labelId, { order: lo.order, customColor: lo.customColor }]),
+      );
+
+      return labels
+        .map((label) => ({
+          ...label,
+          order: orderMap.get(label.id)?.order ?? 999999,
+          color: orderMap.get(label.id)?.customColor || label.color,
+        }))
+        .sort((a, b) => a.order - b.order);
     }),
   create: activeDriverProcedure
     .use(
@@ -55,11 +84,56 @@ export const labelsRouter = router({
     .mutation(async ({ ctx, input }) => {
       const { activeConnection } = ctx;
       const agent = await getZeroAgent(activeConnection.id);
+
+      let labelColor = input.color;
+      if (!labelColor.backgroundColor || !labelColor.textColor) {
+        const randomColor = LABEL_COLORS[Math.floor(Math.random() * LABEL_COLORS.length)];
+        labelColor = randomColor;
+      }
+
       const label = {
         ...input,
+        color: labelColor,
         type: 'user',
       };
-      return await agent.createLabel(label);
+
+      await agent.createLabel(label);
+
+      const allLabels = await agent.getUserLabels();
+      const createdLabel = allLabels.find((l) => l.name === label.name);
+
+      if (createdLabel?.id) {
+        const { db, conn } = createDb(env.HYPERDRIVE.connectionString);
+        try {
+          const maxOrderResult = await db
+            .select({ maxOrder: sql<number>`COALESCE(MAX("order"), -1)` })
+            .from(labelOrder)
+            .where(eq(labelOrder.connectionId, activeConnection.id));
+
+          const nextOrder = (maxOrderResult[0]?.maxOrder ?? -1) + 1;
+
+          await db
+            .insert(labelOrder)
+            .values({
+              id: nanoid(),
+              connectionId: activeConnection.id,
+              labelId: createdLabel.id,
+              order: nextOrder,
+              customColor: labelColor,
+            })
+            .onConflictDoUpdate({
+              target: [labelOrder.connectionId, labelOrder.labelId],
+              set: {
+                customColor: labelColor,
+                updatedAt: new Date(),
+              },
+            });
+        } finally {
+          await conn.end();
+        }
+      }
+
+      return createdLabel || { name: label.name, color: labelColor, type: 'user' };
     }),
   update: activeDriverProcedure
     .use(
@@ -100,4 +174,50 @@ export const labelsRouter = router({
       const agent = await getZeroAgent(activeConnection.id);
       return await agent.deleteLabel(input.id);
     }),
+  reorder: activeDriverProcedure
+    .use(
+      createRateLimiterMiddleware({
+        generatePrefix: ({ sessionUser }) => `ratelimit:labels-reorder-${sessionUser?.id}`,
+        limiter: Ratelimit.slidingWindow(30, '1m'),
+      }),
+    )
+    .input(
+      z.object({
+        labelOrders: z.array(
+          z.object({
+            id: z.string(),
+            order: z.number(),
+          }),
+        ),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      const { activeConnection } = ctx;
+      const agent = await getZeroAgent(activeConnection.id);
+
+      const orderValues = input.labelOrders.map((lo) => lo.order);
+      if (orderValues.some((order) => order < 0)) {
+        throw new Error('Order values must be non-negative');
+      }
+
+      const uniqueOrders = new Set(orderValues);
+      if (uniqueOrders.size !== orderValues.length) {
+        throw new Error('Order values must be unique');
+      }
+
+      await agent.updateLabelOrders(input.labelOrders);
+      return { success: true };
+    }),
+  getOrders: activeDriverProcedure.query(async ({ ctx }) => {
+    const { activeConnection } = ctx;
+    const agent = await getZeroAgent(activeConnection.id);
+    const labelOrders = await agent.getLabelOrders();
+
+    const ordersMap: Record<string, number> = {};
+    labelOrders.forEach((lo) => {
+      ordersMap[lo.labelId] = lo.order;
+    });
+
+    return Object.keys(ordersMap).length > 0 ? ordersMap : null;
+  }),
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -587,6 +587,9 @@ importers:
       mimetext:
         specifier: ^3.0.27
         version: 3.0.27
+      nanoid:
+        specifier: 5.1.5
+        version: 5.1.5
       p-retry:
         specifier: 6.2.1
         version: 6.2.1


### PR DESCRIPTION
# Add drag-and-drop reordering for labels

This PR implements a drag-and-drop interface for reordering labels in the settings page. Labels can now be visually rearranged using a drag handle, and their order is persisted to the database. The order is respected throughout the application, including in the sidebar navigation.

## Technical changes:
- Added `@dnd-kit` for drag-and-drop functionality in the labels settings page
- Created a new database table `mail0_label_order` to store label ordering and custom colors
- Added server-side endpoints to fetch and update label orders
- Modified label creation to assign random colors when none are specified
- Updated sidebar to respect the saved label order when displaying labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Labels can now be reordered via drag-and-drop in the settings interface.
  * Label order is saved and synced across devices.
  * Sidebar and label lists now respect custom label ordering.
  * Added support for custom label colors with server-assigned defaults.

* **Bug Fixes**
  * Improved sorting of folder groups and labels based on explicit order rather than alphabetical order.

* **Chores**
  * Database updated to support label ordering and custom colors.
  * New translation messages for label reordering success and failure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->