### PR TITLE
Fix: Attachment Dropdown Trigger Fix

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -1637,6 +1637,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                               </DropdownMenuItem>
                               <DropdownMenuItem
                                 disabled={!emailData.attachments?.length}
+                                className={!emailData.attachments?.length ? "data-[disabled]:pointer-events-auto" : ""}
                                 onClick={(e) => {
                                   e.stopPropagation();
                                   e.preventDefault();


### PR DESCRIPTION
Fixes #1539 

Possible Solutions 

1. remove `data-[disabled]:pointer-events-none` from DropdownMenuItem as radix-ui has issue presently in how it handles when pointer-events-none is added + Also this affects the dropdown in all places used.

Maybe we can use something like `data-[disabled]:cursor-not-allowed`.
2. added classname only to this specific component with pointer-events-auto to work normally along with disabled.

I have went with 2 at present as other affects it many places.


https://github.com/user-attachments/assets/289a821b-8c23-4d72-ac88-10742df2017c



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the appearance and interactivity of the "Download All Attachments" menu item when no attachments are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->