### PR TITLE
Remove text selection popover causing issues

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -131,7 +131,7 @@ function TextSelectionPopover({
   return (
     <div className="relative" ref={popoverTriggerRef}>
       {children}
-      {selectionCoords && (
+      {/* {selectionCoords && (
         <div
           ref={popoverRef}
           className="absolute z-50"
@@ -190,7 +190,7 @@ function TextSelectionPopover({
             </PopoverContent>
           </Popover>
         </div>
-      )}
+      )} */}
     </div>
   );
 }


### PR DESCRIPTION
# Temporarily Disable Text Selection Popover in Mail Display

## Description

This PR temporarily disables the text selection popover functionality in the mail display component by commenting out the conditional rendering block. The change maintains the component structure while preventing the popover from appearing when text is selected.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] User Interface/Experience

## Testing Done

- [x] Manual testing performed

## Additional Notes

This is a temporary fix to address issues with the text selection popover. A more comprehensive solution will be implemented in a future PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Disabled the popover UI that appears on text selection within the mail display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->