### PR TITLE
getqoutauser

### DIFF
--- a/apps/server/src/lib/driver/google.ts
+++ b/apps/server/src/lib/driver/google.ts
@@ -216,7 +216,7 @@ export class GoogleMailManager implements MailManager {
   }
 
   private getQuotaUser() {
-    return this.config.auth?.email + `-${env.NODE_ENV}`;
+    return this.config.auth?.email ? `${this.config.auth.email}-${env.NODE_ENV}` : undefined;
   }
   public list(params: {
     folder: string;


### PR DESCRIPTION
# Refactor Google Mail Manager quota user handling

## Description

Added a new `getQuotaUser()` method to the GoogleMailManager class that combines the user's email with the current environment (`NODE_ENV`). Updated all Google API calls to use this method instead of directly using the email as the quota user.

This change helps prevent quota limit issues by creating environment-specific quota user identifiers, which is particularly useful when running multiple environments (development, staging, production) with the same Google account.

---

## Type of Change

- [x] ⚡ Performance improvement

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)

## Testing Done

- [x] Manual testing performed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

This change helps prevent hitting Google API quota limits by differentiating quota usage across different environments.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved handling of user identification for Gmail API requests to enhance consistency across different environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->