### PR TITLE
disallow last conn del

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -201,6 +201,10 @@ class ZeroDB extends DurableObject<Env> {
   }
 
   async deleteConnection(connectionId: string, userId: string) {
+    const connections = await this.findManyConnections(userId);
+    if (connections.length <= 1) {
+      throw new Error('Cannot delete the last connection. At least one connection is required.');
+    }
     return await this.db
       .delete(connection)
       .where(and(eq(connection.id, connectionId), eq(connection.userId, userId)));


### PR DESCRIPTION
# Prevent users from deleting their last connection

## Description

Added a validation check before deleting a connection to ensure users always maintain at least one connection. The system now throws an error if a user attempts to delete their last remaining connection.

---

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] Data Storage/Management
- [x] API Endpoints

## Testing Done

- [x] Manual testing performed

## Security Considerations

- [x] No sensitive data is exposed
- [x] Input validation is implemented

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

This change prevents users from getting into a state where they have no connections, which could lead to unexpected behavior in the application.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented users from deleting their last remaining connection, ensuring at least one connection always remains.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->