### PR TITLE
#fix: Ensure label list updates immediately after label creation + Added Black color as pre-selected color of labels.

### DIFF
--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -63,12 +63,12 @@ export function LabelDialog({
       if (editingLabel) {
         form.reset({
           name: editingLabel.name,
-          color: editingLabel.color || { backgroundColor: '#202020', textColor: '#FFFFFF' },
+          color: editingLabel.color || { backgroundColor: '#E2E2E2', textColor: '#000000' },
         });
       } else {
         form.reset({
           name: '',
-          color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
+          color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
         });
       }
     }
@@ -84,7 +84,7 @@ export function LabelDialog({
     setDialogOpen(false);
     form.reset({
       name: '',
-      color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
+      color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
     });
   };
 

--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -16,6 +16,11 @@ import {
 import { CurvedArrow } from '@/components/icons/icons';
 import { LABEL_COLORS } from '@/lib/label-colors';
 import type { Label as LabelType } from '@/types';
+
+const DEFAULT_LABEL_COLORS = {
+  backgroundColor: '#202020',
+  textColor: '#FFFFFF',
+} as const;
 import { Button } from '@/components/ui/button';
 import { Label } from '@/components/ui/label';
 import { Input } from '@/components/ui/input';
@@ -49,10 +54,7 @@ export function LabelDialog({
   const form = useForm<LabelType>({
     defaultValues: {
       name: '',
-      color: {
-        backgroundColor: '#202020',
-        textColor: '#FFFFFF',
-      },
+      color: DEFAULT_LABEL_COLORS,
     },
   });
   const formColor = form.watch('color');
@@ -68,7 +70,7 @@ export function LabelDialog({
       } else {
         form.reset({
           name: '',
-          color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
+          color: DEFAULT_LABEL_COLORS,
         });
       }
     }
@@ -84,7 +86,7 @@ export function LabelDialog({
     setDialogOpen(false);
     form.reset({
       name: '',
-      color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
+      color: DEFAULT_LABEL_COLORS,
     });
   };
 

--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -50,13 +50,11 @@ export function LabelDialog({
     defaultValues: {
       name: '',
       color: {
-        backgroundColor: '',
-        textColor: '',
+        backgroundColor: '#202020',
+        textColor: '#FFFFFF',
       },
     },
   });
-
-  const formColor = form.watch('color');
 
   // Reset form when editingLabel changes or dialog opens
   useEffect(() => {
@@ -64,12 +62,12 @@ export function LabelDialog({
       if (editingLabel) {
         form.reset({
           name: editingLabel.name,
-          color: editingLabel.color || { backgroundColor: '#E2E2E2', textColor: '#000000' },
+          color: editingLabel.color || { backgroundColor: '#202020', textColor: '#FFFFFF' },
         });
       } else {
         form.reset({
           name: '',
-          color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
+          color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
         });
       }
     }
@@ -85,7 +83,7 @@ export function LabelDialog({
     setDialogOpen(false);
     form.reset({
       name: '',
-      color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
+      color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
     });
   };
 
@@ -132,8 +130,8 @@ export function LabelDialog({
                         key={color.backgroundColor}
                         type="button"
                         className={`h-10 w-10 rounded-[4px] border-[0.5px] border-white/10 transition-all ${
-                          formColor?.backgroundColor.toString() === color.backgroundColor &&
-                          formColor.textColor.toString() === color.textColor
+                          form.watch('color')?.backgroundColor === color.backgroundColor &&
+                          form.watch('color')?.textColor === color.textColor
                             ? 'scale-110 ring-2 ring-blue-500 ring-offset-1'
                             : 'hover:scale-105'
                         }`}

--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -68,7 +68,7 @@ export function LabelDialog({
       } else {
         form.reset({
           name: '',
-          color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
+          color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
         });
       }
     }
@@ -84,7 +84,7 @@ export function LabelDialog({
     setDialogOpen(false);
     form.reset({
       name: '',
-      color: { backgroundColor: '#E2E2E2', textColor: '#000000' },
+      color: { backgroundColor: '#202020', textColor: '#FFFFFF' },
     });
   };
 

--- a/apps/mail/components/labels/label-dialog.tsx
+++ b/apps/mail/components/labels/label-dialog.tsx
@@ -55,6 +55,7 @@ export function LabelDialog({
       },
     },
   });
+  const formColor = form.watch('color');
 
   // Reset form when editingLabel changes or dialog opens
   useEffect(() => {
@@ -130,8 +131,8 @@ export function LabelDialog({
                         key={color.backgroundColor}
                         type="button"
                         className={`h-10 w-10 rounded-[4px] border-[0.5px] border-white/10 transition-all ${
-                          form.watch('color')?.backgroundColor === color.backgroundColor &&
-                          form.watch('color')?.textColor === color.textColor
+                          formColor?.backgroundColor.toString() === color.backgroundColor &&
+                          formColor.textColor.toString() === color.textColor
                             ? 'scale-110 ring-2 ring-blue-500 ring-offset-1'
                             : 'hover:scale-105'
                         }`}

--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -173,16 +173,9 @@ export function NavMain({ items }: NavMainProps) {
   );
 
   const onSubmit = async (data: LabelType) => {
-    try {
-      await createLabel(data);
-      toast.success('Label created successfully');
-      
-      setTimeout(() => {
-        refetch();
-      }, 200);
-    } catch (error) {
-      toast.error('Failed to create label');
-    }
+    await createLabel(data);
+    toast.success('Label created successfully');
+    setTimeout(() => refetch(), 200);
   };
 
   return (

--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -173,11 +173,16 @@ export function NavMain({ items }: NavMainProps) {
   );
 
   const onSubmit = async (data: LabelType) => {
-    toast.promise(createLabel(data), {
-      loading: 'Creating label...',
-      success: 'Label created successfully',
-      error: 'Failed to create label',
-    });
+    try {
+      await createLabel(data);
+      toast.success('Label created successfully');
+      
+      setTimeout(() => {
+        refetch();
+      }, 200);
+    } catch (error) {
+      toast.error('Failed to create label');
+    }
   };
 
   return (

--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -173,14 +173,16 @@ export function NavMain({ items }: NavMainProps) {
   );
 
   const onSubmit = async (data: LabelType) => {
-    try {
-      await createLabel(data);
-      toast.success('Label created successfully');
-      setTimeout(() => refetch(), 200);
-    } catch (error) {
-      toast.error('Failed to create label. Please try again.');
-      console.error('Label creation failed:', error);
-    }
+    toast.promise(
+      createLabel(data).then(() => {
+        refetch();
+      }),
+      {
+        loading: 'Creating label...',
+        success: 'Label created successfully',
+        error: 'Failed to create label',
+      }
+    );
   };
 
   return (

--- a/apps/mail/components/ui/nav-main.tsx
+++ b/apps/mail/components/ui/nav-main.tsx
@@ -173,9 +173,14 @@ export function NavMain({ items }: NavMainProps) {
   );
 
   const onSubmit = async (data: LabelType) => {
-    await createLabel(data);
-    toast.success('Label created successfully');
-    setTimeout(() => refetch(), 200);
+    try {
+      await createLabel(data);
+      toast.success('Label created successfully');
+      setTimeout(() => refetch(), 200);
+    } catch (error) {
+      toast.error('Failed to create label. Please try again.');
+      console.error('Label creation failed:', error);
+    }
   };
 
   return (

--- a/apps/server/src/trpc/routes/label.ts
+++ b/apps/server/src/trpc/routes/label.ts
@@ -50,7 +50,11 @@ export const labelsRouter = router({
     .mutation(async ({ ctx, input }) => {
       const { activeConnection } = ctx;
       const agent = await getZeroAgent(activeConnection.id);
-      return await agent.createLabel(input);
+      const label = {
+        ...input,
+        type: 'user',
+      };
+      return await agent.createLabel(label);
     }),
   update: activeDriverProcedure
     .use(

--- a/apps/server/src/trpc/routes/label.ts
+++ b/apps/server/src/trpc/routes/label.ts
@@ -49,7 +49,7 @@ export const labelsRouter = router({
         color: z.object({
           backgroundColor: z.string().regex(/^#[0-9A-F]{6}$/i, 'Must be a valid hex color').default(DEFAULT_LABEL_COLORS.backgroundColor),
           textColor: z.string().regex(/^#[0-9A-F]{6}$/i, 'Must be a valid hex color').default(DEFAULT_LABEL_COLORS.textColor),
-        }),
+        }).default(DEFAULT_LABEL_COLORS),
       }),
     )
     .mutation(async ({ ctx, input }) => {

--- a/apps/server/src/trpc/routes/label.ts
+++ b/apps/server/src/trpc/routes/label.ts
@@ -3,6 +3,11 @@ import { getZeroAgent } from '../../lib/server-utils';
 import { Ratelimit } from '@upstash/ratelimit';
 import { z } from 'zod';
 
+const DEFAULT_LABEL_COLORS = {
+  backgroundColor: '#202020',
+  textColor: '#FFFFFF',
+} as const;
+
 export const labelsRouter = router({
   list: activeDriverProcedure
     .use(
@@ -42,8 +47,8 @@ export const labelsRouter = router({
       z.object({
         name: z.string(),
         color: z.object({
-          backgroundColor: z.string().default('#202020'),
-          textColor: z.string().default('#FFFFFF'),
+          backgroundColor: z.string().regex(/^#[0-9A-F]{6}$/i, 'Must be a valid hex color').default(DEFAULT_LABEL_COLORS.backgroundColor),
+          textColor: z.string().regex(/^#[0-9A-F]{6}$/i, 'Must be a valid hex color').default(DEFAULT_LABEL_COLORS.textColor),
         }),
       }),
     )

--- a/apps/server/src/trpc/routes/label.ts
+++ b/apps/server/src/trpc/routes/label.ts
@@ -47,19 +47,15 @@ export const labelsRouter = router({
             textColor: z.string(),
           })
           .default({
-            backgroundColor: '',
-            textColor: '',
+            backgroundColor: '#202020',
+            textColor: '#FFFFFF',
           }),
       }),
     )
     .mutation(async ({ ctx, input }) => {
       const { activeConnection } = ctx;
       const agent = await getZeroAgent(activeConnection.id);
-      const label = {
-        ...input,
-        type: 'user',
-      };
-      return await agent.createLabel(label);
+      return await agent.createLabel(input);
     }),
   update: activeDriverProcedure
     .use(

--- a/apps/server/src/trpc/routes/label.ts
+++ b/apps/server/src/trpc/routes/label.ts
@@ -41,15 +41,10 @@ export const labelsRouter = router({
     .input(
       z.object({
         name: z.string(),
-        color: z
-          .object({
-            backgroundColor: z.string(),
-            textColor: z.string(),
-          })
-          .default({
-            backgroundColor: '#202020',
-            textColor: '#FFFFFF',
-          }),
+        color: z.object({
+          backgroundColor: z.string().default('#202020'),
+          textColor: z.string().default('#FFFFFF'),
+        }),
       }),
     )
     .mutation(async ({ ctx, input }) => {


### PR DESCRIPTION
## What does this PR do?
- Fixes #1687 
- Fixes [ZERO-343](https://linear.app/0email/issue/ZERO-343/latest-label-is-not-getting-fetched-after-creating-new-label)

## Description

This PR addresses two improvements related to the label creation experience:

1. **Label creation delay fix**:
   Previously, when a new label was created via the sidebar "+" button, it wouldn’t show up immediately in the labels list. Users had to refresh the page or create another label to see the first one. This has been resolved by ensuring the label creation (`labels.create`) completes before triggering a fresh fetch (`labels.list`). The result is a smoother and more intuitive experience.

2. **Default color selection**:
   When opening the "Create Label" dialog, no color was selected by default, which could be confusing. The first color option (black) is now pre-selected automatically when the dialog opens, offering a more consistent and user-friendly interaction.

---

## Type of Change

* [x] 🐛 Bug fix (non-breaking change which fixes an issue)
* [x] ✨ New feature (non-breaking change which adds functionality)
* [x] 🎨 UI/UX improvement

---

## Areas Affected

* [x] User Interface/Experience
* [x] API Endpoints

---

## Testing Done

* [x] Manual testing performed

**Manual Test Coverage:**

* Verified that newly created labels appear instantly in the sidebar list
* Confirmed default color (black) is pre-selected in the create label dialog
* Checked that color selection can still be changed by the user
* Ensured existing label editing and creation flows are not broken

---

## Security Considerations

* [x] No sensitive data is exposed
* [x] Authentication checks are in place
* [x] Input validation is implemented

---

## Checklist

* [x] I have read the [[CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md)](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
* [x] My code follows the project's style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code, particularly in complex areas
* [x] My changes generate no new warnings
* [x] All tests pass locally

---

## Additional Notes

### Technical Details:

* The label creation logic now awaits a successful creation response before triggering a refetch, improving the label list synchronization.
* A 200ms delay was added to allow the backend to persist the label before fetching.
* The default color logic has been updated in both the frontend dialog and server schema for consistency.
* These changes affect only \~21 lines across 3 files, maintaining backward compatibility.

**Files modified:**

* `nav-main.tsx` – Updated label creation logic to improve UI sync
* `label-dialog.tsx` – Added logic for default color selection
* `label.ts` – Updated default color value on the server side

---

## Screenshots/Recordings:


Before fix:


https://github.com/user-attachments/assets/cc45d912-96ba-4788-8d63-b31a887d0bf9

After fix:


https://github.com/user-attachments/assets/81cdb442-ab92-435f-9270-4471a858bbd0

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Newly created labels now appear instantly in the sidebar, and the "Create Label" dialog pre-selects black as the default color.

- **Bug Fixes**
  - Fixed label list not updating immediately after creating a new label.

- **UI Improvements**
  - Set black as the default selected color when opening the create label dialog.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated default label colors to a dark theme with improved contrast, using a dark background and white text for new labels.

* **User Experience**
  * Success messages for label creation are now shown more consistently, with a brief delay before refreshing the label list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->