### PR TITLE
fix: Clicking a deselected mail opens it instead of reselecting

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -231,7 +231,7 @@ const Thread = memo(
             className={cn(
               'hover:bg-offsetLight hover:bg-primary/5 group relative mx-1 flex cursor-pointer flex-col items-start rounded-lg py-2 text-left text-sm transition-all hover:opacity-100',
               (isMailSelected || isMailBulkSelected || isKeyboardFocused) &&
-                'border-border bg-primary/5 opacity-100',
+              'border-border bg-primary/5 opacity-100',
               isKeyboardFocused && 'ring-primary/50',
               'relative',
               'group',
@@ -363,26 +363,47 @@ const Thread = memo(
                       <Check className="h-4 w-4 text-white" />
                     </div>
                   </Avatar>
-                ) : isGroupThread ? (
-                  <Avatar
-                    className={cn(
-                      'h-8 w-8 rounded-full',
-                      displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
-                    )}
-                  >
-                    <div className="flex h-full w-full items-center justify-center rounded-full bg-[#FFFFFF] p-2 dark:bg-[#373737]">
-                      <GroupPeople className="h-4 w-4" />
-                    </div>
-                  </Avatar>
                 ) : (
-                  <BimiAvatar
-                    email={latestMessage.sender.email}
-                    name={cleanName || latestMessage.sender.email}
-                    className={cn(
-                      'h-8 w-8 rounded-full',
-                      displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
-                    )}
-                  />
+                  <div
+                    className="rounded-full"
+                    onClick={(e) => {
+                      if(mailState.bulkSelected.length === 0) return;
+
+                      e.stopPropagation();
+
+                      setMail((prev: Config) => ({
+                        ...prev,
+                        bulkSelected: [
+                          ...prev.bulkSelected,
+                          latestMessage.id
+                        ]
+                      }))
+                    }}
+                  >
+                    {
+                      isGroupThread ? (
+                        <Avatar
+                          className={cn(
+                            'h-8 w-8 rounded-full',
+                            displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
+                          )}
+                        >
+                          <div className="flex h-full w-full items-center justify-center rounded-full bg-[#FFFFFF] p-2 dark:bg-[#373737]">
+                            <GroupPeople className="h-4 w-4" />
+                          </div>
+                        </Avatar>
+                      ) : (
+                        <BimiAvatar
+                          email={latestMessage.sender.email}
+                          name={cleanName || latestMessage.sender.email}
+                          className={cn(
+                            'h-8 w-8 rounded-full',
+                            displayUnread && !isMailSelected && !isFolderSent ? '' : 'border',
+                          )}
+                        />
+                      )
+                    }
+                  </div>
                 )}
                 {/* {displayUnread && !isMailSelected && !isFolderSent ? (
                   <>


### PR DESCRIPTION
## Description

When using the "Select All" checkbox to select all emails, if the user manually deselects one email and then clicks on it again to reselect, or clicks on the emails that are not selected, the email gets opened instead of being selected.

---

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🎨 UI/UX improvement

## Areas Affected

- [ ] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [ ] Manual testing performed
- [ ] Cross-browser testing
- [ ] Mobile responsiveness verified

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] My changes generate no new warnings

## Screenshots/Recordings

<img width="527" height="624" alt="image" src="https://github.com/user-attachments/assets/3cc4106d-572b-41aa-a75c-6c4b7999f34e" />


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed an issue where clicking a deselected email after using "Select All" would open the email instead of reselecting it.

- **Bug Fixes**
  - Clicking a deselected email now reselects it when in bulk selection mode.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to bulk-select emails by clicking on the avatar when bulk selection is active.

* **Style**
  * Minor indentation adjustment for improved code readability (no visible user impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->