### PR TITLE
Fix/note panel mobile responsive

### DIFF
--- a/apps/mail/components/mail/note-panel.tsx
+++ b/apps/mail/components/mail/note-panel.tsx
@@ -526,7 +526,7 @@ export function NotesPanel({ threadId }: NotesPanelProps) {
 
       {isOpen && (
         <div
-          className="animate-in fade-in-20 zoom-in-95 dark:bg-panelDark fixed top-[5rem] z-50 h-[calc(100dvh-5rem)] max-h-[calc(100dvh-5rem)] w-full max-w-[100vw] overflow-hidden rounded-t-lg border border-t bg-[#FAFAFA] shadow-lg duration-100 sm:absolute sm:right-0 sm:top-full sm:mt-2 sm:h-auto sm:max-h-[80vh] sm:w-[350px] sm:max-w-[90vw] sm:rounded-xl sm:border lg:left-[-200px] xl:left-[-300px] dark:border-[#252525]"
+          className="animate-in fade-in-20 zoom-in-95 sm:left-none dark:bg-panelDark fixed left-0 top-[5rem] z-50 h-[calc(100dvh-5rem)] max-h-[calc(100dvh-5rem)] w-full max-w-[100vw] overflow-hidden rounded-t-lg border border-t bg-[#FAFAFA] shadow-lg duration-100 sm:absolute sm:left-[-300px] sm:top-full sm:mt-2 sm:h-auto sm:max-h-[80vh] sm:w-[350px] sm:max-w-[90vw] sm:rounded-xl sm:border lg:left-[-300px] xl:left-[-300px] dark:border-[#252525]"
           onClick={handlePanelClick}
         >
           <div className="sticky top-0 z-10 flex items-center justify-between border-b border-[#E7E7E7] p-3 dark:border-[#252525]">


### PR DESCRIPTION
## Description

##### Fix note panel and make it responsive on mobile (issue #1484)

Initially, the panel was partially visible on mobile devices, with half of it rendered off-screen, as shown below:
<img height="auto" width="300" alt="Screen Shot 2025-07-15 at 18 17 06" src="https://github.com/user-attachments/assets/b4bcb743-6668-48a9-8282-773c71e8bf2c" />


---

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [✔] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [✔] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [✔] My code follows the project's style guidelines
- [✔] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [✔] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

Add any other context about the pull request here.

## Screenshots/Recordings
After the fix, the panel is now fully visible on mobile devices, as shown below:
mobile:
<img width="300" height="auto" alt="Screen Shot 2025-07-16 at 15 46 36" src="https://github.com/user-attachments/assets/6c0c2606-aaf3-402b-a18f-f006efd56fb4" />
Ipad:
<img width="1010" height="auto" alt="Screen Shot 2025-07-16 at 15 46 51" src="https://github.com/user-attachments/assets/64bf3d05-94ec-4e89-a627-c90fe30e70c0" />
big screen
<img width="6344" height="3040" alt="Screen Shot 2025-07-16 at 15 48 35" src="https://github.com/user-attachments/assets/00bb5745-d703-445e-90ac-10247f47fea5" />
<img width="4980" height="3040" alt="Screen Shot 2025-07-16 at 15 47 26" src="https://github.com/user-attachments/assets/efbbbf23-2bf6-44db-878c-237f27084b62" />


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the note panel layout so it displays correctly on mobile devices. The panel now stays within the screen on all viewports.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the notes panel positioning for improved responsiveness and consistent layout across different screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->