### PR TITLE
Refactor Google mail count implementation and add staleTime to stats query

### DIFF
--- a/apps/mail/app/(routes)/settings/notifications/page.tsx
+++ b/apps/mail/app/(routes)/settings/notifications/page.tsx
@@ -38,7 +38,7 @@ export default function NotificationsPage() {
     },
   });
 
-  function onSubmit(values: z.infer<typeof formSchema>) {
+  function onSubmit() {
     setIsSaving(true);
     setTimeout(() => {
       setIsSaving(false);

--- a/apps/mail/hooks/use-stats.ts
+++ b/apps/mail/hooks/use-stats.ts
@@ -9,6 +9,7 @@ export const useStats = () => {
   const statsQuery = useQuery(
     trpc.mail.count.queryOptions(void 0, {
       enabled: !!session?.user.id,
+      staleTime: 1000 * 60 * 5, // 1 hour
     }),
   );
 


### PR DESCRIPTION
# Optimize mail app performance and refactor Google mail manager

## Description

This PR makes several improvements to the mail application:

1. Removed unused parameter in the `onSubmit` function in the notifications settings page
2. Added a 5-minute stale time to the mail count query to reduce unnecessary API calls
3. Completely refactored the Google mail manager's count method to use Effect.js more effectively:
   - Implemented concurrent fetching of user labels and archive count
   - Improved error handling with more specific error types
   - Restructured the code to be more maintainable with a cleaner data flow
   - Added better type safety throughout the implementation

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ⚡ Performance improvement

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [x] Performance

## Testing Done

- [x] Manual testing performed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] All tests pass locally

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and reliability of email label and archive count retrieval.
  * Updated internal form handling for notification settings.
  * Enhanced caching behavior for statistics, reducing unnecessary data fetching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->