### PR TITLE
chore: remove extra arguments from AiChatPrompt fn

### DIFF
--- a/apps/mail/components/ui/prompts-dialog.tsx
+++ b/apps/mail/components/ui/prompts-dialog.tsx
@@ -48,7 +48,7 @@ const initialValues: Record<EPrompts, string> = {
 };
 
 const fallbackPrompts = {
-  [EPrompts.Chat]: AiChatPrompt('', '', ''),
+  [EPrompts.Chat]: AiChatPrompt(''),
   [EPrompts.Compose]: StyledEmailAssistantSystemPrompt(),
   [EPrompts.SummarizeThread]: SummarizeThread,
   [EPrompts.ReSummarizeThread]: ReSummarizeThread,

--- a/apps/server/src/lib/brain.ts
+++ b/apps/server/src/lib/brain.ts
@@ -47,7 +47,7 @@ export const getPrompts = async ({ connectionId }: { connectionId: string }) => 
     [EPrompts.SummarizeMessage]: SummarizeMessage,
     [EPrompts.ReSummarizeThread]: ReSummarizeThread,
     [EPrompts.SummarizeThread]: SummarizeThread,
-    [EPrompts.Chat]: AiChatPrompt('', '', ''),
+    [EPrompts.Chat]: AiChatPrompt(''),
     [EPrompts.Compose]: StyledEmailAssistantSystemPrompt(),
     // [EPrompts.ThreadLabels]: '',
   };


### PR DESCRIPTION
The function AiChatPrompt() only takes a single argument.
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed extra arguments from the Chat prompt function call to match its single-argument signature.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated the way fallback prompts are constructed for chat, with no visible impact on user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->