### PR TITLE
feat: add starred mail section to sidebar navigation

### DIFF
--- a/apps/mail/app/(routes)/mail/[folder]/page.tsx
+++ b/apps/mail/app/(routes)/mail/[folder]/page.tsx
@@ -6,7 +6,16 @@ import { authProxy } from '@/lib/auth-proxy';
 import { useEffect, useState } from 'react';
 import type { Route } from './+types/page';
 
-const ALLOWED_FOLDERS = new Set(['inbox', 'draft', 'sent', 'spam', 'bin', 'archive', 'snoozed']);
+const ALLOWED_FOLDERS = new Set([
+  'inbox',
+  'draft',
+  'sent',
+  'spam',
+  'bin',
+  'archive',
+  'snoozed',
+  'starred',
+]);
 
 export async function clientLoader({ params, request }: Route.ClientLoaderArgs) {
   if (!params.folder) return Response.redirect(`${import.meta.env.VITE_PUBLIC_APP_URL}/mail/inbox`);

--- a/apps/mail/app/root.tsx
+++ b/apps/mail/app/root.tsx
@@ -65,7 +65,8 @@ export async function loader(_: LoaderFunctionArgs) {
 }
 
 export function Layout({ children }: PropsWithChildren) {
-  const { connectionId } = useLoaderData<typeof loader>();
+  const loaderData = useLoaderData<typeof loader>();
+  const connectionId = loaderData?.connectionId || 'defaultConnection';
 
   return (
     <html lang={getLocale()} suppressHydrationWarning>

--- a/apps/mail/config/navigation.ts
+++ b/apps/mail/config/navigation.ts
@@ -83,6 +83,13 @@ export const navigationConfig: Record<string, NavConfig> = {
             shortcut: 'g + a',
           },
           {
+            id: 'starred',
+            title: m['navigation.sidebar.starred'](),
+            url: '/mail/starred',
+            icon: Stars,
+            shortcut: 'g + s',
+          },
+          {
             id: 'snoozed',
             title: m['navigation.sidebar.snoozed'](),
             url: '/mail/snoozed',

--- a/apps/mail/messages/en.json
+++ b/apps/mail/messages/en.json
@@ -406,7 +406,8 @@
       "feedback": "Feedback",
       "settings": "Settings",
       "voice": "Voice Assistant",
-      "snoozed": "Snoozed"
+      "snoozed": "Snoozed",
+      "starred": "Starred"
     },
     "settings": {
       "general": "General",


### PR DESCRIPTION

This PR introduces a dedicated "Starred" section to the main sidebar navigation, making it much easier for users to access their most important emails. And I am aware of the filter by starred in categories, but as a Mail0 user, I think starred deserves a dedicated section.

The "Starred" link is located directly under "Archive" for easy discovery.

Key Changes:

Adds the "Starred" item to the sidebar UI and navigation logic.

Wires it up to the /mail/starred route, which uses the existing STARRED label filter.

Includes translations for the new section.

Fixes a minor bug in the root loader to ensure stability.

Updates the allowed folders list to include starred.

I've confirmed the following works as expected:
✅ The "Starred" section appears in the sidebar.
✅ Clicking it correctly navigates to /mail/starred.
✅ The view displays only starred emails.
✅ The keyboard shortcut g + s navigates to the starred view.

This is a non-breaking change and integrates seamlessly with the existing star/unstar functionality.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a "Starred" section to the sidebar navigation so users can quickly access their starred emails.

- **New Features**
  - Sidebar now includes a "Starred" link under "Archive".
  - Clicking "Starred" navigates to /mail/starred and shows only starred emails.
  - Added keyboard shortcut (g + s) for fast access.
  - Updated translations and allowed folders to support the new section.

- **Bug Fixes**
  - Fixed a minor issue in the root loader for better stability.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Starred" folder to the list of mail folders, allowing users to access starred emails directly.
  * Introduced a "Starred" navigation item in the sidebar with a dedicated icon and keyboard shortcut (g + s).
* **Bug Fixes**
  * Improved reliability when retrieving the mail connection ID by providing a default fallback value.
* **Documentation**
  * Updated English localization to include the "Starred" sidebar label.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->