### PR TITLE
fix: auto-focus reply input when reply is triggered

### DIFF
--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -257,7 +257,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
         initialCc={ensureEmailArray(draft?.cc)}
         initialBcc={ensureEmailArray(draft?.bcc)}
         initialSubject={draft?.subject}
-        autofocus={false}
+        autofocus={true}
         settingsLoading={settingsLoading}
         replyingTo={replyToMessage?.sender.email}
       />


### PR DESCRIPTION
# Description

Fixes #1840 
Auto-focuses the reply input when a reply is triggered via button click or keyboard shortcut.

## Type of Change

Please delete options that are not relevant.

- [x] 🎨 UI/UX improvement

## Areas Affected

Please check all that apply:

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

## Screenshots/Recordings


https://github.com/user-attachments/assets/bddc3d6c-d2c0-42e2-8a3e-b3fc1a694f14



---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
The reply input now auto-focuses when a reply is triggered, making it faster to start typing a response.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * The email composer input field now automatically receives focus when replying to an email, making it easier to start composing your response immediately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->