### PR TITLE
Dedicated Per-thread Workers for Thread Syncing

### DIFF
--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -42,6 +42,7 @@ import { cors } from 'hono/cors';
 import { Effect } from 'effect';
 
 import { Hono } from 'hono';
+import { ThreadSyncWorker } from './routes/agent/sync-worker';
 
 const SENTRY_HOST = 'o4509328786915328.ingest.us.sentry.io';
 const SENTRY_PROJECT_IDS = new Set(['4509328795303936']);
@@ -854,4 +855,4 @@ export default class extends WorkerEntrypoint<typeof env> {
   }
 }
 
-export { ZeroAgent, ZeroMCP, ZeroDB, ZeroDriver, ThinkingMCP };
+export { ZeroAgent, ZeroMCP, ZeroDB, ZeroDriver, ThinkingMCP, ThreadSyncWorker };

--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -483,12 +483,8 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
     // console.log('Server: syncThread called for thread', threadId);
     try {
-      // const threadData = await this.getWithRetry(threadId);
-      // const latest = threadData.latest;
       const threadSyncWorker = env.THREAD_SYNC_WORKER.get(env.THREAD_SYNC_WORKER.newUniqueId());
       const latest = await threadSyncWorker.syncThread(this.name, this._connection, threadId);
-      // @ts-expect-error
-      threadSyncWorker[Symbol.dispose]?.();
 
       if (latest) {
         // Convert receivedOn to ISO format for proper sorting
@@ -499,12 +495,6 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
           console.log('Here!', error);
           normalizedReceivedOn = new Date().toISOString();
         }
-
-        // await env.THREADS_BUCKET.put(this.getThreadKey(threadId), JSON.stringify(threadData), {
-        //   customMetadata: {
-        //     threadId,
-        //   },
-        // });
 
         void this.sql`
       INSERT OR REPLACE INTO threads (
@@ -533,12 +523,7 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
             threadId,
           });
         this.syncThreadsInProgress.delete(threadId);
-        // console.log('Server: syncThread result', {
-        //   threadId,
-        //   labels: threadData.labels,
-        // });
-        // return { success: true, threadId, threadData };
-        return { success: true, threadId }; // removed threadData
+        return { success: true, threadId }; // removed threadData from return; seemed to be unused
       } else {
         this.syncThreadsInProgress.delete(threadId);
         console.log(`Skipping thread ${threadId} - no latest message`);
@@ -588,51 +573,19 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
     const self = this;
 
+    // Use the dedicated ThreadSyncWorker durable object
     const fetchThread = (threadId: string) =>
       Effect.gen(function* () {
         yield* Effect.sleep(200);
 
-        const threadData = yield* Effect.tryPromise(() => self.getWithRetry(threadId));
+        const result = yield* Effect.tryPromise(() => self.syncThread({ threadId }));
 
-        if (!threadData || !threadData.latest || !threadData.latest.threadId) {
+        if (result && result.success) {
+          return 1 as const;
+        } else {
+          console.log(`Failed to sync thread ${threadId}:`, result?.reason || 'Unknown error');
           return 0 as const;
         }
-        const latest = threadData.latest!;
-        const id = latest.threadId as string;
-
-        const serialized = JSON.stringify(threadData);
-        yield* Effect.tryPromise(() =>
-          env.THREADS_BUCKET.put(self.getThreadKey(id), serialized, {
-            customMetadata: { threadId: id },
-          }),
-        );
-
-        const normalizedReceivedOn = new Date(latest.receivedOn).toISOString();
-        yield* Effect.try(
-          () =>
-            self.sql`
-            INSERT OR REPLACE INTO threads (
-              id, thread_id, provider_id, latest_sender,
-              latest_received_on, latest_subject, latest_label_ids, updated_at
-            ) VALUES (
-              ${id},
-              ${id},
-              'google',
-              ${JSON.stringify(latest.sender)},
-              ${normalizedReceivedOn},
-              ${latest.subject},
-              ${JSON.stringify(latest.tags.map((tag) => tag.id))},
-              CURRENT_TIMESTAMP
-            )
-          `,
-        );
-
-        self.agent?.broadcastChatMessage({
-          type: OutgoingMessageType.Mail_Get,
-          threadId: id,
-        });
-
-        return 1 as const;
       }).pipe(
         Effect.catchAll((error) => {
           console.error(`Failed to process thread ${threadId} in ${folder}:`, error);
@@ -1048,7 +1001,7 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
       let currentLabels: string[];
       try {
-        currentLabels = JSON.parse(result[0].latest_label_ids || '[]') as string[];
+        currentLabels = JSON.parse(result[0].latest_label_ids?.toString() || '[]') as string[];
       } catch (error) {
         console.error(`Invalid JSON in latest_label_ids for thread ${threadId}:`, error);
         currentLabels = [];

--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -483,7 +483,9 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
     // console.log('Server: syncThread called for thread', threadId);
     try {
+      // Get a new ThreadSyncWorker Durable Object stub
       const threadSyncWorker = env.THREAD_SYNC_WORKER.get(env.THREAD_SYNC_WORKER.newUniqueId());
+      // Sync thread with the worker
       const latest = await threadSyncWorker.syncThread(this.name, this._connection, threadId);
 
       if (latest) {
@@ -573,12 +575,12 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
     const self = this;
 
-    // Use the dedicated ThreadSyncWorker durable object
-    const fetchThread = (threadId: string) =>
+    const executeSyncThread = (threadId: string) =>
       Effect.gen(function* () {
-        yield* Effect.sleep(200);
+        yield * Effect.sleep(200);
 
-        const result = yield* Effect.tryPromise(() => self.syncThread({ threadId }));
+        // Uses the dedicated ThreadSyncWorker durable object
+        const result = yield * Effect.tryPromise(() => self.syncThread({ threadId }));
 
         if (result && result.success) {
           return 1 as const;
@@ -612,7 +614,7 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
           const threadIds = result.threads.map((thread) => thread.id);
 
-          const processedCounts = yield* Effect.all(threadIds.map(fetchThread), {
+          const processedCounts = yield* Effect.all(threadIds.map(executeSyncThread), {
             concurrency: 3,
           });
 

--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -65,6 +65,7 @@ const shouldLoop = env.THREAD_SYNC_LOOP !== 'false';
 export class ZeroDriver extends AIChatAgent<typeof env> {
   private foldersInSync: Map<string, boolean> = new Map();
   private syncThreadsInProgress: Map<string, boolean> = new Map();
+  private _connection: typeof connection.$inferSelect | undefined = undefined;
   private driver: MailManager | null = null;
   private agent: DurableObjectStub<ZeroAgent> | null = null;
   constructor(ctx: DurableObjectState, env: Env) {
@@ -163,10 +164,10 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
     if (this.name === 'general') return;
     if (!this.driver) {
       const { db, conn } = createDb(env.HYPERDRIVE.connectionString);
-      const _connection = await db.query.connection.findFirst({
+      this._connection = await db.query.connection.findFirst({
         where: eq(connection.id, this.name),
       });
-      if (_connection) this.driver = connectionToDriver(_connection);
+      if (this._connection) this.driver = connectionToDriver(this._connection);
       this.ctx.waitUntil(conn.end());
       this.ctx.waitUntil(this.syncThreads('inbox'));
       this.ctx.waitUntil(this.syncThreads('sent'));
@@ -389,6 +390,11 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
       throw new Error('No driver available');
     }
 
+    if (!this._connection) {
+      console.error('No connection available for syncThread');
+      throw new Error('No connection available');
+    }
+
     if (this.syncThreadsInProgress.has(threadId)) {
       console.log(`Sync already in progress for thread ${threadId}, skipping...`);
       return;
@@ -397,8 +403,12 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
     // console.log('Server: syncThread called for thread', threadId);
     try {
-      const threadData = await this.getWithRetry(threadId);
-      const latest = threadData.latest;
+      // const threadData = await this.getWithRetry(threadId);
+      // const latest = threadData.latest;
+      const threadSyncWorker = env.THREAD_SYNC_WORKER.get(env.THREAD_SYNC_WORKER.newUniqueId());
+      const latest = await threadSyncWorker.syncThread(this.name, this._connection, threadId);
+      // @ts-expect-error
+      threadSyncWorker[Symbol.dispose]?.();
 
       if (latest) {
         // Convert receivedOn to ISO format for proper sorting
@@ -410,11 +420,11 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
           normalizedReceivedOn = new Date().toISOString();
         }
 
-        await env.THREADS_BUCKET.put(this.getThreadKey(threadId), JSON.stringify(threadData), {
-          customMetadata: {
-            threadId,
-          },
-        });
+        // await env.THREADS_BUCKET.put(this.getThreadKey(threadId), JSON.stringify(threadData), {
+        //   customMetadata: {
+        //     threadId,
+        //   },
+        // });
 
         void this.sql`
       INSERT OR REPLACE INTO threads (
@@ -447,7 +457,8 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
         //   threadId,
         //   labels: threadData.labels,
         // });
-        return { success: true, threadId, threadData };
+        // return { success: true, threadId, threadData };
+        return { success: true, threadId }; // removed threadData
       } else {
         this.syncThreadsInProgress.delete(threadId);
         console.log(`Skipping thread ${threadId} - no latest message`);
@@ -529,7 +540,7 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
           const threadIds = result.threads.map((thread) => thread.id);
           const syncEffects = threadIds.map(syncSingleThread);
 
-          yield* Effect.all(syncEffects, { concurrency: 1, discard: true });
+          yield* Effect.all(syncEffects, { concurrency: 10 });
 
           totalSynced += result.threads.length;
           pageToken = result.nextPageToken;

--- a/apps/server/src/routes/agent/sync-worker.ts
+++ b/apps/server/src/routes/agent/sync-worker.ts
@@ -1,0 +1,47 @@
+import { connectionToDriver } from '../../lib/server-utils';
+import { connection } from '../../db/schema';
+
+import { DurableObject, env, RpcTarget } from 'cloudflare:workers';
+import { withRetry } from '../../lib/gmail-rate-limit';
+import type { ParsedMessage } from '../../types';
+import { Effect } from 'effect';
+
+export class ThreadSyncWorker extends DurableObject<Env> {
+  constructor(state: DurableObjectState, env: Env) {
+    super(state, env);
+  }
+
+  private getThreadKey(connectionId: string, threadId: string) {
+    return `${connectionId}/${threadId}.json`;
+  }
+
+  public async syncThread(
+    connectionId: string,
+    _connection: typeof connection.$inferSelect,
+    threadId: string,
+  ): Promise<ParsedMessage | undefined> {
+    console.log('THREAD_SYNC_WORKER: Syncing thread', connectionId, threadId);
+
+    const driver = connectionToDriver(_connection);
+    if (!driver) throw new Error('No driver available');
+
+    // Get thread
+    const thread = await Effect.runPromise(
+      withRetry(Effect.tryPromise(() => driver!.get(threadId))),
+    );
+
+    await env.THREADS_BUCKET.put(
+      this.getThreadKey(connectionId, threadId),
+      JSON.stringify(thread),
+      {
+        customMetadata: {
+          threadId,
+        },
+      },
+    );
+
+    console.log('THREAD_SYNC_WORKER: Thread synced', connectionId, threadId);
+
+    return thread.latest;
+  }
+}

--- a/apps/server/src/routes/agent/sync-worker.ts
+++ b/apps/server/src/routes/agent/sync-worker.ts
@@ -1,7 +1,7 @@
 import { connectionToDriver } from '../../lib/server-utils';
 import { connection } from '../../db/schema';
 
-import { DurableObject, env, RpcTarget } from 'cloudflare:workers';
+import { DurableObject, env } from 'cloudflare:workers';
 import { withRetry } from '../../lib/gmail-rate-limit';
 import type { ParsedMessage } from '../../types';
 import { Effect } from 'effect';

--- a/apps/server/src/routes/agent/sync-worker.ts
+++ b/apps/server/src/routes/agent/sync-worker.ts
@@ -20,8 +20,7 @@ export class ThreadSyncWorker extends DurableObject<Env> {
     _connection: typeof connection.$inferSelect,
     threadId: string,
   ): Promise<ParsedMessage | undefined> {
-    console.log('THREAD_SYNC_WORKER: Syncing thread', connectionId, threadId);
-
+    // Get driver from connection
     const driver = connectionToDriver(_connection);
     if (!driver) throw new Error('No driver available');
 
@@ -30,6 +29,7 @@ export class ThreadSyncWorker extends DurableObject<Env> {
       withRetry(Effect.tryPromise(() => driver!.get(threadId))),
     );
 
+    // Store thread
     await env.THREADS_BUCKET.put(
       this.getThreadKey(connectionId, threadId),
       JSON.stringify(thread),
@@ -40,8 +40,7 @@ export class ThreadSyncWorker extends DurableObject<Env> {
       },
     );
 
-    console.log('THREAD_SYNC_WORKER: Thread synced', connectionId, threadId);
-
+    // Return latest message in thread
     return thread.latest;
   }
 }

--- a/apps/server/wrangler.jsonc
+++ b/apps/server/wrangler.jsonc
@@ -47,6 +47,10 @@
             "name": "THINKING_MCP",
             "class_name": "ThinkingMCP",
           },
+          {
+            "name": "THREAD_SYNC_WORKER",
+            "class_name": "ThreadSyncWorker",
+          },
         ],
       },
       "queues": {
@@ -93,6 +97,10 @@
         {
           "tag": "v6",
           "new_sqlite_classes": ["ThinkingMCP"],
+        },
+        {
+          "tag": "v7",
+          "new_classes": ["ThreadSyncWorker"],
         },
       ],
 


### PR DESCRIPTION
## Description

Adds a new binding for the `SyncThreadWorker` Durable Object. This Durable Object is designed as a short-lived execution context for syncing an individual mail thread from a provider into R2.

This improves the opportunity for increased parallelization, and critically avoids memory limit issues when syncing many/large threads. Since each Durable Object has a memory limit of 128mb, this allows large threads and large quantities of threads to be synced more reliably.

---

## Type of Change

- [x] ⚡ Performance improvement

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] Data Storage/Management

## Testing Done

Describe the tests you've done:

- [x] Manual testing performed

## Security Considerations

For changes involving data or authentication:

- [x] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in complex areas
- [x] My changes generate no new warnings

## Additional Notes

There is potential for other patterns to be explored: such as creating a pool of the worker threads in a size that matches the concurrency number (currently `3`) and re-using those durable objects for multiple thread syncs. A potential caveat of this is that memory may not be freed between `syncThread()` RPC invocations. This is why I chose the pattern of a new Durable Object for each thread sync execution.
The `ThreadSyncWorker` Durable Object is intentionally designed with no state and no storage to make it as lightweight as possible.

**Important note**: I removed the `threadData` property from the returned object in `syncThreads()` - from my testing and investigating I could not usage of this property.
This is optimal for memory conservation within the `ZeroDriver` DO.
If this is incorrect, and the `threadData` property is used/needed, let me know.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added a dedicated Durable Object worker for each mail thread sync to improve parallelization and prevent memory issues when syncing large or many threads.

- **Performance**
  - Each thread sync now runs in its own short-lived worker, avoiding shared memory limits.
  - Removed unused thread data from sync results to reduce memory usage.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new background worker to handle email thread synchronization, improving reliability and scalability.
* **Bug Fixes**
  * Improved handling of label data to prevent parsing errors during thread label updates.
* **Chores**
  * Updated configuration to support the new background worker for thread synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->