### PR TITLE
Remove brain state dependency and fix Gmail subscription key format

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -38,7 +38,6 @@ import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
 import type { Sender, ParsedMessage, Attachment } from '@/types';
 import { useActiveConnection } from '@/hooks/use-connections';
 import { useAttachments } from '@/hooks/use-attachments';
-import { useBrainState } from '../../hooks/use-summary';
 import { useTRPC } from '@/providers/query-provider';
 import { useThreadLabels } from '@/hooks/use-labels';
 import { useMutation } from '@tanstack/react-query';
@@ -682,7 +681,6 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
   const { labels: threadLabels } = useThreadLabels(
     emailData.tags ? emailData.tags.map((l) => l.id) : [],
   );
-  const { data: brainState } = useBrainState();
   const { data: activeConnection } = useActiveConnection();
   const [researchSender, setResearchSender] = useState<Sender | null>(null);
   const [searchQuery, setSearchQuery] = useState<string | null>(null);
@@ -1315,7 +1313,7 @@ const MailDisplay = ({ emailData, index, totalEmails, demo, threadAttachments }:
                     })()}
                   </div>
                 </div>
-                {brainState?.enabled && <AiSummary />}
+                <AiSummary />
                 {threadAttachments && threadAttachments.length > 0 && (
                   <ThreadAttachments attachments={threadAttachments} />
                 )}

--- a/apps/server/src/main.ts
+++ b/apps/server/src/main.ts
@@ -832,7 +832,7 @@ export default class extends WorkerEntrypoint<typeof env> {
 
     await Promise.all(
       allAccounts.map(async ({ id, providerId }) => {
-        const lastSubscribed = await env.gmail_sub_age.get(id);
+        const lastSubscribed = await env.gmail_sub_age.get(`${id}__${providerId}`);
 
         if (lastSubscribed) {
           const subscriptionDate = new Date(lastSubscribed);

--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -1360,12 +1360,13 @@ export class ZeroDriver extends AIChatAgent<typeof env> {
 
     try {
       folder = this.normalizeFolderName(folder);
-      const folderThreadCount = (await this.count()).find((c) => c.label === folder)?.count;
-      const currentThreadCount = await this.getThreadCount();
+      // TODO: Sometimes the DO storage is resetting
+      //   const folderThreadCount = (await this.count()).find((c) => c.label === folder)?.count;
+      //   const currentThreadCount = await this.getThreadCount();
 
-      if (folderThreadCount && folderThreadCount > currentThreadCount && folder) {
-        this.ctx.waitUntil(this.syncThreads(folder));
-      }
+      //   if (folderThreadCount && folderThreadCount > currentThreadCount && folder) {
+      //     this.ctx.waitUntil(this.syncThreads(folder));
+      //   }
 
       // Build WHERE conditions
       const whereConditions: string[] = [];


### PR DESCRIPTION
# Fix AI Summary Display and Gmail Subscription Key Format

## Description

This PR includes three key changes:

1. Removed the conditional rendering of the `AiSummary` component based on `brainState.enabled`, allowing the component to handle its own visibility logic.
2. Fixed the Gmail subscription key format in the server by using a composite key format `${id}__${providerId}` instead of just `id` when accessing the `gmail_sub_age` KV store.
3. Temporarily commented out thread synchronization logic in the agent routes due to issues with Durable Object storage resetting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [x] Data Storage/Management

## Testing Done

- [x] Manual testing performed

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

## Additional Notes

The commented-out thread synchronization code includes a TODO note explaining that the Durable Object storage is sometimes resetting. This is a temporary measure until we can properly address the underlying issue.

---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AI summary is now always displayed in the mail display, regardless of previous conditions.
  * Improved accuracy in tracking Google subscription expiration by distinguishing between different account-provider pairs.

* **Chores**
  * Temporarily disabled folder sync trigger in thread retrieval due to intermittent storage resets; sync logic will be revisited in the future.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->