### PR TITLE
fix: add draft generation check

### DIFF
--- a/apps/server/src/thread-workflow-utils/workflow-engine.ts
+++ b/apps/server/src/thread-workflow-utils/workflow-engine.ts
@@ -115,7 +115,7 @@ export const createDefaultWorkflows = (): WorkflowEngine => {
           if (executionCheck?.alreadyExecuted) {
             return false;
           }
-          return shouldGenerateDraft(context.thread, context.foundConnection);
+          return await shouldGenerateDraft(context.thread, context.foundConnection);
         },
         action: async (context) => {
           console.log('[WORKFLOW_ENGINE] Thread eligible for draft generation', {

--- a/apps/server/src/thread-workflow-utils/workflow-functions.ts
+++ b/apps/server/src/thread-workflow-utils/workflow-functions.ts
@@ -18,7 +18,7 @@ export type WorkflowFunction = (context: WorkflowContext) => Promise<any>;
 
 export const workflowFunctions: Record<string, WorkflowFunction> = {
   shouldGenerateDraft: async (context) => {
-    return shouldGenerateDraft(context.thread, context.foundConnection);
+    return await shouldGenerateDraft(context.thread, context.foundConnection);
   },
 
   checkWorkflowExecution: async (context) => {
@@ -80,6 +80,11 @@ export const workflowFunctions: Record<string, WorkflowFunction> = {
 
   generateAutomaticDraft: async (context) => {
     console.log('[WORKFLOW_FUNCTIONS] Generating automatic draft for thread:', context.threadId);
+    console.log('[WORKFLOW_FUNCTIONS] Thread has', context.thread.messages.length, 'messages');
+    console.log(
+      '[WORKFLOW_FUNCTIONS] Latest message from:',
+      context.thread.messages[context.thread.messages.length - 1]?.sender?.email,
+    );
 
     const draftContent = await generateAutomaticDraft(
       context.connectionId,


### PR DESCRIPTION
# Prevent duplicate draft generation by checking existing drafts

## Description

This PR enhances the `shouldGenerateDraft` function to prevent generating duplicate drafts for the same email thread. The function now:

1. Checks if a draft already exists for the thread by calling the Gmail API
2. Skips draft generation if a draft is already present for that thread
3. Logs the decision for better debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved draft generation logic to prevent creating duplicate drafts for the same thread.
  * Enhanced workflow reliability by ensuring eligibility checks are properly awaited.

* **Chores**
  * Added detailed logging for draft generation, including thread message counts and sender information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->