### PR TITLE
Fix: Display full sender email in sender details box

### DIFF
--- a/apps/mail/components/mail/mail-display.tsx
+++ b/apps/mail/components/mail/mail-display.tsx
@@ -242,7 +242,7 @@ const MailDisplayLabels = ({ labels }: { labels: string[] }) => {
 // Helper function to clean email display
 const cleanEmailDisplay = (email?: string) => {
   if (!email) return '';
-  const match = email.match(/^[^a-zA-Z]*(.*?)[^a-zA-Z]*$/);
+  const match = email.match(/([a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,})/);
   return match ? match[1] : email;
 };
 


### PR DESCRIPTION
## Description

When an email is sent from addresses like `22b81a05q2@cvr.ac.in`, the sender details box was incorrectly displaying only `b81a05q2@cvr.ac.in`, cutting off the initial digits.

Fixes #1909 

---

## Type of Change

Please delete options that are not relevant.

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature with breaking changes)
- [ ] 📝 Documentation update
- [ ] 🎨 UI/UX improvement
- [ ] 🔒 Security enhancement
- [ ] ⚡ Performance improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [x] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published

## Additional Notes

Updated the `cleanEmailDisplay` function to use a more reliable pattern that correctly identifies and preserves valid email addresses, even if they begin with digits.

## Screenshots/Recordings

<img width="1053" height="317" alt="image" src="https://github.com/user-attachments/assets/348d361c-5417-48a7-858f-caa550253383" />


---

_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed the sender details box to show the full email address, including leading digits, for all senders.

- **Bug Fixes**
 - Updated the email parsing logic to correctly display emails that start with numbers.

<!-- End of auto-generated description by cubic. -->

