### PR TITLE
fix: remove double toast and decrease time from 30s to 15s

### DIFF
--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -14,7 +14,6 @@ import { useDraft } from '@/hooks/use-drafts';
 import { useEffect, useState } from 'react';
 
 import type { Attachment } from '@/types';
-import { m } from '@/paraglide/messages';
 import { useQueryState } from 'nuqs';
 import { X } from '../icons/icons';
 import posthog from 'posthog-js';
@@ -122,7 +121,6 @@ export function CreateEmail({
       posthog.capture('Create Email Sent');
     }
 
-    toast.success(m['pages.createEmail.emailSentSuccessfully']());
     handleUndoSend(result, settings);
   };
 

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -210,10 +210,7 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
       // Reset states
       setMode(null);
       await refetch();
-      toast.success(m['pages.createEmail.emailSent']());
-      setTimeout(() => {
-        handleUndoSend(result, settings);
-      }, 500);
+      handleUndoSend(result, settings);
     } catch (error) {
       console.error('Error sending email:', error);
       toast.error(m['pages.createEmail.failedToSendEmail']());

--- a/apps/mail/hooks/use-undo-send.ts
+++ b/apps/mail/hooks/use-undo-send.ts
@@ -13,7 +13,7 @@ export const useUndoSend = () => {
     if (isSendResult(result) && settings?.settings?.undoSendEnabled) {
       const { messageId, sendAt } = result;
 
-      const timeRemaining = sendAt ? sendAt - Date.now() : 30_000;
+      const timeRemaining = sendAt ? sendAt - Date.now() : 15_000;
 
       if (timeRemaining > 5_000) {
         toast.success('Email scheduled', {
@@ -28,7 +28,7 @@ export const useUndoSend = () => {
               }
             },
           },
-          duration: timeRemaining,
+          duration: 15_000,
         });
       }
     }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Removed duplicate success toasts when sending emails and reduced the undo send toast duration from 30 seconds to 15 seconds.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed success toast notifications after sending an email and when using the reply composer.

* **Refactor**
  * The undo send action in the reply composer is now triggered immediately without delay.

* **Chores**
  * Reduced the undo send window from 30 seconds to 15 seconds, and updated related toast notification durations accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->