### PR TITLE
fix: hotkeys for categories

### DIFF
--- a/apps/mail/components/mail/mail.tsx
+++ b/apps/mail/components/mail/mail.tsx
@@ -678,34 +678,18 @@ function CategoryDropdown({ isMultiSelectMode }: CategoryDropdownProps) {
   const folder = params?.folder ?? 'inbox';
   const [isOpen, setIsOpen] = useState(false);
 
-  categorySettings.forEach((category, index) => {
-    if (index < 9) {
-      const keyNumber = (index + 1).toString();
-      useHotkeys(
-        keyNumber,
-        () => {
-          const isCurrentlyActive = labels.includes(category.searchValue);
-
-          if (isCurrentlyActive) {
-            setLabels(labels.filter((label) => label !== category.searchValue));
-          } else {
-            setLabels([...labels, category.searchValue]);
-          }
-        },
-        {
-          scopes: ['mail-list'],
-          preventDefault: true,
-          enableOnFormTags: false,
-        },
-        [category.searchValue, labels, setLabels], // Dependencies
-      );
-    }
-  });
-
   useHotkeys(
-    '0',
-    () => {
-      setLabels([]);
+    ['1', '2', '3', '4', '5', '6', '7', '8', '9', '0'],
+    (key) => {
+      const category = categorySettings[Number(key.key) - 1];
+      if (!category) return;
+      const isCurrentlyActive = labels.includes(category.searchValue);
+
+      if (isCurrentlyActive) {
+        setLabels(labels.filter((label) => label !== category.searchValue));
+      } else {
+        setLabels([...labels, category.searchValue]);
+      }
     },
     {
       scopes: ['mail-list'],


### PR DESCRIPTION
The new implementation:
- Uses a single `useHotkeys` call with an array of key combinations
- Determines the appropriate category based on the pressed key
- Handles toggling labels in a more centralized way

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified hotkey handling for category selection by consolidating multiple hotkey registrations into a single listener.
  * The '0' key now toggles the 10th category instead of clearing all selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->