### PR TITLE
feat: add auto closing of issues / pull requests based on staleness

### DIFF
--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -14,8 +14,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const { rest } = github;
-            const prs = await rest.pulls.list({
+            const prs = await github.rest.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'open'
@@ -23,7 +22,7 @@ jobs:
 
             const now = new Date();
             for (const pr of prs.data) {
-              const details = await rest.pulls.get({
+              const details = await github.rest.pulls.get({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 pull_number: pr.number
@@ -33,7 +32,14 @@ jobs:
                 const createdAt = new Date(pr.created_at);
                 const diffDays = (now - createdAt) / (1000 * 60 * 60 * 24);
                 if (diffDays > 3) {
-                  await rest.pulls.update({
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body: "This PR has merge conflicts and has been open for more than 3 days. It will be automatically closed. Please resolve the conflicts and reopen the PR if you'd like to continue working on it."
+                  });
+                  
+                  await github.rest.pulls.update({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     pull_number: pr.number,

--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -1,0 +1,42 @@
+name: Close Old Conflicted PRs
+
+on:
+  schedule:
+    - cron: "0 * * * *" 
+
+jobs:
+  close_conflicted_prs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close PRs with merge conflicts older than 3 days
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const { rest } = github;
+            const prs = await rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open'
+            });
+
+            const now = new Date();
+            for (const pr of prs.data) {
+              const details = await rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+
+              if (details.data.mergeable === false) {
+                const createdAt = new Date(pr.created_at);
+                const diffDays = (now - createdAt) / (1000 * 60 * 60 * 24);
+                if (diffDays > 3) {
+                  await rest.pulls.update({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    pull_number: pr.number,
+                    state: 'closed'
+                  });
+                }
+              }
+            }

--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -7,9 +7,11 @@ on:
 jobs:
   close_conflicted_prs:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Close PRs with merge conflicts older than 3 days
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { rest } = github;

--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -28,7 +28,7 @@ jobs:
                 pull_number: pr.number
               });
 
-              if (details.data.mergeable === false) {
+              if (details.data.mergeable === false || details.data.mergeable === null) {
                 const createdAt = new Date(pr.created_at);
                 const diffDays = (now - createdAt) / (1000 * 60 * 60 * 24);
                 if (diffDays > 3) {

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,17 @@
+name: Close Stale Issues
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "*/5 * * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-stale: 0
+          days-before-close: 0
+          stale-issue-message: "This issue is stale and will be closed now."
+          close-issue-message: "Closing this issue."

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,9 +1,8 @@
 name: Close Stale Issues
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "0 * * * *"
 
 jobs:
   stale:
@@ -11,7 +10,7 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-stale: 0
+          days-before-stale: 3
           days-before-close: 0
-          stale-issue-message: "This issue is stale and will be closed now."
-          close-issue-message: "Closing this issue."
+          stale-issue-message: "This issue is stale (3+ days) and will be closed."
+          close-issue-message: "Closing stale issue."

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -12,5 +12,6 @@ jobs:
         with:
           days-before-stale: 3
           days-before-close: 0
+          only-issues: true
           stale-issue-message: "This issue is stale (3+ days) and will be closed."
           close-issue-message: "Closing stale issue."

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - uses: actions/stale@v9
         with:

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -16,5 +16,6 @@ jobs:
           days-before-stale: 3
           days-before-close: 0
           only-issues: true
+          stale-issue-label: "stale"
           stale-issue-message: "This issue is stale (3+ days) and will be closed."
           close-issue-message: "Closing stale issue."


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added GitHub workflows to automatically close stale issues and pull requests with unresolved merge conflicts older than 3 days.

- **Automation**
  - Closes open pull requests with merge conflicts after 3 days.
  - Closes issues immediately when marked as stale.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Introduced automated workflows to close old pull requests with unresolved merge conflicts and to close stale issues, helping keep the repository clean and up to date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->