### PR TITLE
fix: update cron schedule and improve conflict detection in PR closures

### DIFF
--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -2,7 +2,7 @@ name: Close Old Conflicted PRs
 
 on:
   schedule:
-    - cron: "0 * * * *" 
+    - cron: "0 0 * * *"
 
 jobs:
   close_conflicted_prs:
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Close PRs with merge conflicts older than 3 days
+      - name: Close PRs with conflicts older than 3 days
         uses: actions/github-script@v7
         with:
           script: |
@@ -28,15 +28,31 @@ jobs:
                 pull_number: pr.number
               });
 
-              if (details.data.mergeable === false || details.data.mergeable === null) {
-                const createdAt = new Date(pr.created_at);
-                const diffDays = (now - createdAt) / (1000 * 60 * 60 * 24);
-                if (diffDays > 3) {
+              if (details.data.mergeable === false) {
+                // Get the timeline of events to find when conflicts started
+                const timeline = await github.rest.issues.listEventsForTimeline({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number
+                });
+
+                let conflictStartTime = new Date(pr.updated_at);
+                
+                for (const event of timeline.data) {
+                  if (event.event === 'cross-referenced' && event.commit_id) {
+                    conflictStartTime = new Date(event.created_at);
+                    break;
+                  }
+                }
+
+                const conflictAgeDays = (now - conflictStartTime) / (1000 * 60 * 60 * 24);
+                
+                if (conflictAgeDays > 3) {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,
                     issue_number: pr.number,
-                    body: "This PR has merge conflicts and has been open for more than 3 days. It will be automatically closed. Please resolve the conflicts and reopen the PR if you'd like to continue working on it."
+                    body: "This PR has had merge conflicts for more than 3 days. It will be automatically closed. Please resolve the conflicts and reopen the PR if you'd like to continue working on it."
                   });
                   
                   await github.rest.pulls.update({

--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -33,7 +33,7 @@ jobs:
               }
               
               if (details.data.mergeable === false) {
-                const timeline = await github.rest.issues.listEventsForTimeline({
+                const timeline = await github.rest.issues.listEventsForTimeline({ owner: context.repo.owner, repo: context.repo.repo, issue_number: pr.number, per_page: 100 });
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: pr.number

--- a/.github/workflows/close-conflicted-prs.yml
+++ b/.github/workflows/close-conflicted-prs.yml
@@ -28,8 +28,11 @@ jobs:
                 pull_number: pr.number
               });
 
+              if (details.data.mergeable === null) {
+                continue;
+              }
+              
               if (details.data.mergeable === false) {
-                // Get the timeline of events to find when conflicts started
                 const timeline = await github.rest.issues.listEventsForTimeline({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
@@ -47,7 +50,7 @@ jobs:
 
                 const conflictAgeDays = (now - conflictStartTime) / (1000 * 60 * 60 * 24);
                 
-                if (conflictAgeDays > 3) {
+                if (conflictAgeDays >= 3) {
                   await github.rest.issues.createComment({
                     owner: context.repo.owner,
                     repo: context.repo.repo,

--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -2,7 +2,7 @@ name: Close Stale Issues
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "0 0 * * *"
 
 jobs:
   stale:


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Updated the cron schedule for closing conflicted PRs and stale issues to run daily at midnight. Improved the conflicted PR closure workflow to detect how long a PR has actually had merge conflicts before closing it.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated scheduled workflows to run daily at midnight instead of hourly.
  * Improved the process for identifying and closing pull requests with unresolved conflicts, ensuring more accurate conflict timing and clearer notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->