### PR TITLE
feat: add email right back into the composer once you click undo

### DIFF
--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -1,4 +1,4 @@
-import { useUndoSend, type EmailData } from '@/hooks/use-undo-send';
+import { useUndoSend, type EmailData, deserializeFiles } from '@/hooks/use-undo-send';
 import { useActiveConnection } from '@/hooks/use-connections';
 import { Dialog, DialogClose } from '@/components/ui/dialog';
 import { useEmailAliases } from '@/hooks/use-email-aliases';
@@ -108,6 +108,7 @@ export function CreateEmail({
     });
 
     setDraftId(null);
+    clearUndoData();
 
     // Track different email sending scenarios
     if (data.cc && data.cc.length > 0 && data.bcc && data.bcc.length > 0) {
@@ -145,19 +146,29 @@ export function CreateEmail({
     return cleanedAddresses || [];
   };
 
+  const clearUndoData = () => {
+    if (typeof window !== 'undefined') {
+      localStorage.removeItem('undoEmailData');
+    }
+  };
+
   const undoEmailData = useMemo((): EmailData | null => {
     if (isComposeOpen !== 'true') return null;
+    if (typeof window === 'undefined') return null;
     
     const storedData = localStorage.getItem('undoEmailData');
     if (!storedData) return null;
     
     try {
       const parsedData = JSON.parse(storedData);
-      localStorage.removeItem('undoEmailData');
+      
+      if (parsedData.attachments && Array.isArray(parsedData.attachments)) {
+        parsedData.attachments = deserializeFiles(parsedData.attachments);
+      }
+      
       return parsedData;
     } catch (error) {
       console.error('Failed to parse undo email data:', error);
-      localStorage.removeItem('undoEmailData');
       return null;
     }
   }, [isComposeOpen]);
@@ -169,6 +180,7 @@ export function CreateEmail({
     setIsComposeOpen(open ? 'true' : null);
     if (!open) {
       setDraftId(null);
+      clearUndoData();
     }
   };
 
@@ -242,6 +254,7 @@ export function CreateEmail({
                 setActiveReplyId(null);
                 setIsComposeOpen(null);
                 setDraftId(null);
+                clearUndoData();
               }}
               initialAttachments={undoEmailData?.attachments || files}
               initialSubject={

--- a/apps/mail/components/create/create-email.tsx
+++ b/apps/mail/components/create/create-email.tsx
@@ -1,4 +1,4 @@
-import { useUndoSend } from '@/hooks/use-undo-send';
+import { useUndoSend, type EmailData } from '@/hooks/use-undo-send';
 import { useActiveConnection } from '@/hooks/use-connections';
 import { Dialog, DialogClose } from '@/components/ui/dialog';
 import { useEmailAliases } from '@/hooks/use-email-aliases';
@@ -11,7 +11,7 @@ import { EmailComposer } from './email-composer';
 import { useSession } from '@/lib/auth-client';
 import { serializeFiles } from '@/lib/schemas';
 import { useDraft } from '@/hooks/use-drafts';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import type { Attachment } from '@/types';
 import { useQueryState } from 'nuqs';
@@ -107,7 +107,6 @@ export function CreateEmail({
       scheduleAt: data.scheduleAt,
     });
 
-    // Clear draft ID from URL
     setDraftId(null);
 
     // Track different email sending scenarios
@@ -121,7 +120,16 @@ export function CreateEmail({
       posthog.capture('Create Email Sent');
     }
 
-    handleUndoSend(result, settings);
+    handleUndoSend(result, settings, {
+      to: data.to,
+      cc: data.cc,
+      bcc: data.bcc,
+      subject: data.subject,
+      message: data.message,
+      attachments: data.attachments,
+      fromEmail: data.fromEmail,
+      scheduleAt: data.scheduleAt,
+    });
   };
 
   useEffect(() => {
@@ -136,6 +144,23 @@ export function CreateEmail({
     const cleanedAddresses = cleanEmailAddresses(emailStr);
     return cleanedAddresses || [];
   };
+
+  const undoEmailData = useMemo((): EmailData | null => {
+    if (isComposeOpen !== 'true') return null;
+    
+    const storedData = localStorage.getItem('undoEmailData');
+    if (!storedData) return null;
+    
+    try {
+      const parsedData = JSON.parse(storedData);
+      localStorage.removeItem('undoEmailData');
+      return parsedData;
+    } catch (error) {
+      console.error('Failed to parse undo email data:', error);
+      localStorage.removeItem('undoEmailData');
+      return null;
+    }
+  }, [isComposeOpen]);
 
   // Cast draft to our extended type that includes CC and BCC
   const typedDraft = draft as unknown as DraftType;
@@ -189,19 +214,26 @@ export function CreateEmail({
             </div>
           ) : (
             <EmailComposer
-              key={typedDraft?.id || 'composer'}
+              key={typedDraft?.id || undoEmailData?.to?.join(',') || 'composer'}
               className="mb-12 rounded-2xl border"
               onSendEmail={handleSendEmail}
-              initialMessage={typedDraft?.content || initialBody}
+              initialMessage={
+                undoEmailData?.message || 
+                typedDraft?.content || 
+                initialBody
+              }
               initialTo={
+                undoEmailData?.to ||
                 typedDraft?.to?.map((e: string) => e.replace(/[<>]/g, '')) ||
                 processInitialEmails(initialTo)
               }
               initialCc={
+                undoEmailData?.cc ||
                 typedDraft?.cc?.map((e: string) => e.replace(/[<>]/g, '')) ||
                 processInitialEmails(initialCc)
               }
               initialBcc={
+                undoEmailData?.bcc ||
                 typedDraft?.bcc?.map((e: string) => e.replace(/[<>]/g, '')) ||
                 processInitialEmails(initialBcc)
               }
@@ -211,8 +243,12 @@ export function CreateEmail({
                 setIsComposeOpen(null);
                 setDraftId(null);
               }}
-              initialAttachments={files}
-              initialSubject={typedDraft?.subject || initialSubject}
+              initialAttachments={undoEmailData?.attachments || files}
+              initialSubject={
+                undoEmailData?.subject || 
+                typedDraft?.subject || 
+                initialSubject
+              }
               autofocus={false}
               settingsLoading={settingsLoading}
             />

--- a/apps/mail/components/mail/reply-composer.tsx
+++ b/apps/mail/components/mail/reply-composer.tsx
@@ -210,7 +210,16 @@ export default function ReplyCompose({ messageId }: ReplyComposeProps) {
       // Reset states
       setMode(null);
       await refetch();
-      handleUndoSend(result, settings);
+      
+      handleUndoSend(result, settings, {
+        to: data.to,
+        cc: data.cc,
+        bcc: data.bcc,
+        subject: data.subject,
+        message: data.message,
+        attachments: data.attachments,
+        scheduleAt: data.scheduleAt,
+      });
     } catch (error) {
       console.error('Error sending email:', error);
       toast.error(m['pages.createEmail.failedToSendEmail']());

--- a/apps/mail/hooks/use-undo-send.ts
+++ b/apps/mail/hooks/use-undo-send.ts
@@ -16,6 +16,46 @@ export type EmailData = {
   scheduleAt?: string;
 };
 
+export type SerializedFile = {
+  name: string;
+  size: number;
+  type: string;
+  lastModified: number;
+  data: string; 
+};
+
+type SerializableEmailData = Omit<EmailData, 'attachments'> & {
+  attachments: SerializedFile[];
+};
+
+const serializeFiles = async (files: File[]): Promise<SerializedFile[]> => {
+  return Promise.all(
+    files.map(async (file) => ({
+      name: file.name,
+      size: file.size,
+      type: file.type,
+      lastModified: file.lastModified,
+      data: await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve((reader.result as string).split(',')[1]);
+        reader.onerror = reject;
+        reader.readAsDataURL(file);
+      }),
+    }))
+  );
+};
+
+export const deserializeFiles = (serializedFiles: SerializedFile[]): File[] => {
+  return serializedFiles.map(({ data, name, type, lastModified }) => {
+    const byteString = atob(data);
+    const byteArray = new Uint8Array(byteString.length);
+    for (let i = 0; i < byteString.length; i++) {
+      byteArray[i] = byteString.charCodeAt(i);
+    }
+    return new File([byteArray], name, { type, lastModified });
+  });
+};
+
 export const useUndoSend = () => {
   const trpc = useTRPC();
   const { mutateAsync: unsendEmail } = useMutation(trpc.mail.unsend.mutationOptions());
@@ -39,7 +79,12 @@ export const useUndoSend = () => {
                 await unsendEmail({ messageId });
                 
                 if (emailData) {
-                  localStorage.setItem('undoEmailData', JSON.stringify(emailData));
+                  const serializedAttachments = await serializeFiles(emailData.attachments);
+                  const serializableData: SerializableEmailData = {
+                    ...emailData,
+                    attachments: serializedAttachments,
+                  };
+                  localStorage.setItem('undoEmailData', JSON.stringify(serializableData));
                 }
                 
                 const url = new URL(window.location.href);

--- a/apps/mail/hooks/use-undo-send.ts
+++ b/apps/mail/hooks/use-undo-send.ts
@@ -1,6 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
-import { useQueryState } from 'nuqs';
 
 import { useTRPC } from '@/providers/query-provider';
 import { isSendResult } from '@/lib/email-utils';
@@ -20,11 +19,6 @@ export type EmailData = {
 export const useUndoSend = () => {
   const trpc = useTRPC();
   const { mutateAsync: unsendEmail } = useMutation(trpc.mail.unsend.mutationOptions());
-  
-  const [, setIsComposeOpen] = useQueryState('isComposeOpen');
-  const [, setDraftId] = useQueryState('draftId');
-  const [, setActiveReplyId] = useQueryState('activeReplyId');
-  const [, setMode] = useQueryState('mode');
 
   const handleUndoSend = (
     result: unknown, 
@@ -48,10 +42,12 @@ export const useUndoSend = () => {
                   localStorage.setItem('undoEmailData', JSON.stringify(emailData));
                 }
                 
-                setActiveReplyId(null);
-                setMode(null);
-                setDraftId(null);
-                setIsComposeOpen('true');
+                const url = new URL(window.location.href);
+                url.searchParams.delete('activeReplyId');
+                url.searchParams.delete('mode');
+                url.searchParams.delete('draftId');
+                url.searchParams.set('isComposeOpen', 'true');
+                window.history.replaceState({}, '', url.toString());
                 
                 toast.info('Send cancelled');
               } catch {

--- a/apps/mail/hooks/use-undo-send.ts
+++ b/apps/mail/hooks/use-undo-send.ts
@@ -1,15 +1,36 @@
 import { useMutation } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { useQueryState } from 'nuqs';
 
 import { useTRPC } from '@/providers/query-provider';
 import { isSendResult } from '@/lib/email-utils';
 import type { UserSettings } from '@zero/server/schemas';
 
+export type EmailData = {
+  to: string[];
+  cc?: string[];
+  bcc?: string[];
+  subject: string;
+  message: string;
+  attachments: File[];
+  fromEmail?: string;
+  scheduleAt?: string;
+};
+
 export const useUndoSend = () => {
   const trpc = useTRPC();
   const { mutateAsync: unsendEmail } = useMutation(trpc.mail.unsend.mutationOptions());
+  
+  const [, setIsComposeOpen] = useQueryState('isComposeOpen');
+  const [, setDraftId] = useQueryState('draftId');
+  const [, setActiveReplyId] = useQueryState('activeReplyId');
+  const [, setMode] = useQueryState('mode');
 
-  const handleUndoSend = (result: unknown, settings: { settings: UserSettings } | undefined) => {
+  const handleUndoSend = (
+    result: unknown, 
+    settings: { settings: UserSettings } | undefined,
+    emailData?: EmailData
+  ) => {
     if (isSendResult(result) && settings?.settings?.undoSendEnabled) {
       const { messageId, sendAt } = result;
 
@@ -22,6 +43,16 @@ export const useUndoSend = () => {
             onClick: async () => {
               try {
                 await unsendEmail({ messageId });
+                
+                if (emailData) {
+                  localStorage.setItem('undoEmailData', JSON.stringify(emailData));
+                }
+                
+                setActiveReplyId(null);
+                setMode(null);
+                setDraftId(null);
+                setIsComposeOpen('true');
+                
                 toast.info('Send cancelled');
               } catch {
                 toast.error('Failed to cancel');


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Restores the email draft in the composer when a user clicks "undo" after sending, so they can edit and resend easily.

- **New Features**
  - Saves email content to local storage on undo and reopens the composer with all fields and attachments restored.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic saving of email content when using the undo send feature, allowing users to restore unsent emails in the compose window.
  * Compose and reply windows now restore email fields (recipients, subject, message, attachments, etc.) if an undo send is triggered.

* **Enhancements**
  * Improved handling of email drafts and restoration, providing a smoother experience when recovering unsent emails.
  * Undo send now persists full email data including attachments, with seamless restoration and clearing of undo data on send or close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->