### PR TITLE
ui: add cross in the undo email toast, decrease time from 30s to 15s

### DIFF
--- a/apps/server/src/trpc/routes/mail.ts
+++ b/apps/server/src/trpc/routes/mail.ts
@@ -515,7 +515,7 @@ export const mailRouter = router({
 
           targetTime = parsedTime;
         } else {
-          targetTime = Date.now() + 30_000;
+          targetTime = Date.now() + 15_000;
         }
 
         const rawDelaySeconds = Math.floor((targetTime - Date.now()) / 1000);


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added a close (cross) button to the undo email toast and reduced the undo window from 30 seconds to 15 seconds. 

- **UI Improvements**
 - The undo toast now shows a close button for quick dismissal.
 - The undo option is available for 15 seconds instead of 30.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Undo experience: separate flows for scheduled vs. immediate sends with clearer toasts. Undoing a scheduled send cancels scheduling; undoing an immediate send restores the draft (including attachments) and reopens the composer. Toasts now last 15 seconds and include a close button.
  * Default delay before processing a send/schedule reduced from 30 seconds to 15 seconds.

* **Bug Fixes**
  * Prevented negative time remaining, ensuring Undo is reliably available and consistent with the 5-second gating.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->