### PR TITLE
feat: optimistic delete draft

### DIFF
--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -6,7 +6,15 @@ import {
   Trash,
   PencilCompose,
 } from '../icons/icons';
-import { memo, useCallback, useEffect, useMemo, useRef, type ComponentProps, useState } from 'react';
+import {
+  memo,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ComponentProps,
+  useState,
+} from 'react';
 import { useOptimisticThreadState } from '@/components/mail/optimistic-thread-state';
 import { focusedIndexAtom, useMailNavigation } from '@/hooks/use-mail-navigation';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -555,16 +563,31 @@ const Thread = memo(
   },
 );
 
-const Draft = memo(({ message }: { message: { id: string } }) => {
+const Draft = memo(({ message, index }: { message: { id: string }; index: number }) => {
   const draftQuery = useDraft(message.id) as UseQueryResult<ParsedDraft>;
   const draft = draftQuery.data;
   const [, setComposeOpen] = useQueryState('isComposeOpen');
   const [, setDraftId] = useQueryState('draftId');
+  const { optimisticDeleteDraft } = useOptimisticActions();
+  const optimisticState = useOptimisticThreadState(message.id);
+
   const handleMailClick = useCallback(() => {
     setComposeOpen('true');
     setDraftId(message.id);
     return;
   }, [message.id]);
+
+  const handleDeleteDraft = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      optimisticDeleteDraft(message.id);
+    },
+    [message.id, optimisticDeleteDraft],
+  );
+
+  if (optimisticState.shouldHide) {
+    return null;
+  }
 
   if (!draft) {
     return (
@@ -607,6 +630,31 @@ const Draft = memo(({ message }: { message: { id: string } }) => {
           'hover:bg-offsetLight dark:hover:bg-primary/5 group relative mx-[8px] flex cursor-pointer flex-col items-start overflow-clip rounded-[10px] border-transparent py-3 text-left text-sm hover:opacity-100',
         )}
       >
+        <div
+          className={cn(
+            'dark:bg-panelDark z-25 absolute right-2 flex -translate-y-1/2 items-center gap-1 rounded-xl border bg-white p-1 opacity-0 shadow-sm group-hover:opacity-100',
+            index === 0 ? 'top-4' : 'top-[-1]',
+          )}
+        >
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6 hover:bg-[#FDE4E9] dark:hover:bg-[#411D23] [&_svg]:size-3.5"
+                onClick={handleDeleteDraft}
+              >
+                <Trash className="fill-[#F43F5E]" />
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent
+              side={index === 0 ? 'bottom' : 'top'}
+              className="dark:bg-panelDark mb-1 bg-white"
+            >
+              {m['common.actions.Bin']()}
+            </TooltipContent>
+          </Tooltip>
+        </div>
         <div
           className={cn(
             'bg-primary absolute inset-y-0 left-0 w-1 -translate-x-2 transition-transform ease-out',
@@ -654,6 +702,8 @@ const Draft = memo(({ message }: { message: { id: string } }) => {
     </div>
   );
 });
+
+Draft.displayName = 'Draft';
 
 export const MailList = memo(
   function MailList() {
@@ -785,7 +835,7 @@ export const MailList = memo(
               const end = Math.max(anchorIndex, clickedIndex);
               const rangeIds = itemsRef.current.slice(start, end + 1).map((item) => item.id);
               const newSelected = [...new Set([...mail.bulkSelected, ...rangeIds])];
-              
+
               return { ...mail, bulkSelected: newSelected };
             }
             default: {

--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -632,9 +632,10 @@ const Draft = memo(({ message, index }: { message: { id: string }; index: number
       >
         <div
           className={cn(
-            'dark:bg-panelDark z-25 absolute right-2 flex -translate-y-1/2 items-center gap-1 rounded-xl border bg-white p-1 opacity-0 shadow-sm group-hover:opacity-100',
-            index === 0 ? 'top-4' : 'top-[-1]',
+            'dark:bg-panelDark shadow-xs absolute right-2 z-20 flex -translate-y-1/2 items-center gap-1 rounded-xl border bg-white p-1 opacity-0 group-hover:opacity-100',
+            index === 0 ? 'top-4' : 'top-[-1px]',
           )}
+          aria-busy={optimisticState.isRemoving}
         >
           <Tooltip>
             <TooltipTrigger asChild>
@@ -642,6 +643,8 @@ const Draft = memo(({ message, index }: { message: { id: string }; index: number
                 variant="ghost"
                 size="icon"
                 className="h-6 w-6 hover:bg-[#FDE4E9] dark:hover:bg-[#411D23] [&_svg]:size-3.5"
+                aria-label="Delete draft"
+                disabled={optimisticState.isRemoving}
                 onClick={handleDeleteDraft}
               >
                 <Trash className="fill-[#F43F5E]" />

--- a/apps/mail/components/mail/mail-list.tsx
+++ b/apps/mail/components/mail/mail-list.tsx
@@ -242,7 +242,7 @@ const Thread = memo(
             <div
               className={cn(
                 'dark:bg-panelDark z-25 absolute right-2 flex -translate-y-1/2 items-center gap-1 rounded-xl border bg-white p-1 opacity-0 shadow-sm group-hover:opacity-100',
-                index === 0 ? 'top-4' : 'top-[-1]',
+                index === 0 ? 'top-4' : 'top-[-1px]',
               )}
             >
               <Tooltip>

--- a/apps/mail/components/mail/optimistic-thread-state.tsx
+++ b/apps/mail/components/mail/optimistic-thread-state.tsx
@@ -82,6 +82,11 @@ export function useOptimisticThreadState(threadId: string) {
           states.shouldHide = true;
           states.optimisticDestination = 'inbox';
           break;
+
+        case 'DELETE_DRAFT':
+          states.shouldHide = true;
+          states.isRemoving = true;
+          break;
       }
     });
 

--- a/apps/mail/hooks/use-optimistic-actions.ts
+++ b/apps/mail/hooks/use-optimistic-actions.ts
@@ -33,7 +33,7 @@ interface ActionParams {
   labelId?: string;
   add?: boolean;
   currentFolder?: string;
-  destination?: string;
+  destination?: ThreadDestination;
   wakeAt?: string;
 }
 
@@ -514,6 +514,7 @@ export function useOptimisticActions() {
       optimisticId,
       execute: async () => {
         await deleteDraft({ id: draftId });
+        await queryClient.invalidateQueries({ queryKey: trpc.drafts.list.queryKey() });
       },
       undo: () => {
         removeOptimisticAction(optimisticId);

--- a/apps/mail/hooks/use-optimistic-actions.ts
+++ b/apps/mail/hooks/use-optimistic-actions.ts
@@ -22,9 +22,22 @@ enum ActionType {
   IMPORTANT = 'IMPORTANT',
   SNOOZE = 'SNOOZE',
   UNSNOOZE = 'UNSNOOZE',
+  DELETE_DRAFT = 'DELETE_DRAFT',
 }
 
-const actionEventNames: Record<ActionType, (params: any) => string> = {
+// Update the params interface
+interface ActionParams {
+  starred?: boolean;
+  read?: boolean;
+  important?: boolean;
+  labelId?: string;
+  add?: boolean;
+  currentFolder?: string;
+  destination?: string;
+  wakeAt?: string;
+}
+
+const actionEventNames: Record<ActionType, (params: ActionParams) => string> = {
   [ActionType.MOVE]: () => 'email_moved',
   [ActionType.STAR]: (params) => (params.starred ? 'email_starred' : 'email_unstarred'),
   [ActionType.READ]: (params) => (params.read ? 'email_marked_read' : 'email_marked_unread'),
@@ -33,6 +46,7 @@ const actionEventNames: Record<ActionType, (params: any) => string> = {
   [ActionType.LABEL]: (params) => (params.add ? 'email_label_added' : 'email_label_removed'),
   [ActionType.SNOOZE]: () => 'email_snoozed',
   [ActionType.UNSNOOZE]: () => 'email_unsnoozed',
+  [ActionType.DELETE_DRAFT]: () => 'draft_deleted',
 };
 
 export function useOptimisticActions() {
@@ -54,6 +68,8 @@ export function useOptimisticActions() {
   const { mutateAsync: snoozeThreads } = useMutation(trpc.mail.snoozeThreads.mutationOptions());
   const { mutateAsync: unsnoozeThreads } = useMutation(trpc.mail.unsnoozeThreads.mutationOptions());
   const { mutateAsync: modifyLabels } = useMutation(trpc.mail.modifyLabels.mutationOptions());
+
+  const { mutateAsync: deleteDraft } = useMutation(trpc.drafts.delete.mutationOptions());
 
   const generatePendingActionId = () =>
     `pending_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
@@ -442,7 +458,7 @@ export function useOptimisticActions() {
     createPendingAction({
       type: 'SNOOZE',
       threadIds,
-      params: { currentFolder, wakeAt: wakeAt.toISOString() } as any,
+      params: { currentFolder, wakeAt: wakeAt.toISOString() },
       optimisticId,
       execute: async () => {
         await snoozeThreads({ ids: threadIds, wakeAt: wakeAt.toISOString() });
@@ -483,6 +499,29 @@ export function useOptimisticActions() {
     });
   }
 
+  function optimisticDeleteDraft(draftId: string) {
+    if (!draftId) return;
+
+    const optimisticId = addOptimisticAction({
+      type: 'DELETE_DRAFT',
+      threadIds: [draftId],
+    });
+
+    createPendingAction({
+      type: 'DELETE_DRAFT',
+      threadIds: [draftId],
+      params: {} as any,
+      optimisticId,
+      execute: async () => {
+        await deleteDraft({ id: draftId });
+      },
+      undo: () => {
+        removeOptimisticAction(optimisticId);
+      },
+      toastMessage: 'Draft deleted',
+    });
+  }
+
   function undoLastAction() {
     if (!optimisticActionsManager.lastActionId) return;
 
@@ -515,6 +554,7 @@ export function useOptimisticActions() {
     optimisticToggleLabel,
     optimisticSnooze,
     optimisticUnsnooze,
+    optimisticDeleteDraft,
     undoLastAction,
   };
 }

--- a/apps/mail/store/optimistic-updates.ts
+++ b/apps/mail/store/optimistic-updates.ts
@@ -8,7 +8,8 @@ export type OptimisticAction =
   | { type: 'LABEL'; threadIds: string[]; labelIds: string[]; add: boolean }
   | { type: 'IMPORTANT'; threadIds: string[]; important: boolean }
   | { type: 'SNOOZE'; threadIds: string[]; wakeAt: string }
-  | { type: 'UNSNOOZE'; threadIds: string[] };
+  | { type: 'UNSNOOZE'; threadIds: string[] }
+  | { type: 'DELETE_DRAFT'; threadIds: string[] };
 
 export const optimisticActionsAtom = atom<Record<string, OptimisticAction>>({});
 

--- a/apps/server/src/lib/driver/google.ts
+++ b/apps/server/src/lib/driver/google.ts
@@ -590,6 +590,18 @@ export class GoogleMailManager implements MailManager {
       { draftId, data },
     );
   }
+  public deleteDraft(draftId: string) {
+    return this.withErrorHandler(
+      'deleteDraft',
+      async () => {
+        await this.gmail.users.drafts.delete({
+          userId: 'me',
+          id: draftId,
+        });
+      },
+      { draftId },
+    );
+  }
   public getDraft(draftId: string) {
     return this.withErrorHandler(
       'getDraft',

--- a/apps/server/src/lib/driver/google.ts
+++ b/apps/server/src/lib/driver/google.ts
@@ -597,6 +597,7 @@ export class GoogleMailManager implements MailManager {
         await this.gmail.users.drafts.delete({
           userId: 'me',
           id: draftId,
+          quotaUser: this.getQuotaUser(),
         });
       },
       { draftId },

--- a/apps/server/src/lib/driver/microsoft.ts
+++ b/apps/server/src/lib/driver/microsoft.ts
@@ -563,6 +563,15 @@ export class OutlookMailManager implements MailManager {
       { draftId },
     );
   }
+  public deleteDraft(draftId: string) {
+    return this.withErrorHandler(
+      'deleteDraft',
+      async () => {
+        await this.graphClient.api(`/me/messages/${draftId}`).delete();
+      },
+      { draftId },
+    );
+  }
   public listDrafts(params: { q?: string; maxResults?: number; pageToken?: string }) {
     const { q, maxResults = 20, pageToken } = params;
     return this.withErrorHandler(

--- a/apps/server/src/lib/driver/microsoft.ts
+++ b/apps/server/src/lib/driver/microsoft.ts
@@ -535,7 +535,7 @@ export class OutlookMailManager implements MailManager {
     return this.withErrorHandler(
       'sendDraft',
       async () => {
-        await this.graphClient.api(`/me/drafts/${draftId}/send`).post({});
+        await this.graphClient.api(`/me/messages/${draftId}/send`).post({});
       },
       { draftId, data },
     );

--- a/apps/server/src/lib/driver/types.ts
+++ b/apps/server/src/lib/driver/types.ts
@@ -74,6 +74,7 @@ export interface MailManager {
     nextPageToken: string | null;
   }>;
   delete(id: string): Promise<void>;
+  deleteDraft(id: string): Promise<void>;
   list(params: {
     folder: string;
     query?: string;

--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -42,8 +42,8 @@ import {
   type ISnoozeBatch,
   type ParsedMessage,
 } from '../../types';
-import { connectionToDriver, getZeroSocketAgent, reSyncThread } from '../../lib/server-utils';
 import type { IGetThreadResponse, IGetThreadsResponse, MailManager } from '../../lib/driver/types';
+import { connectionToDriver, getZeroSocketAgent, reSyncThread } from '../../lib/server-utils';
 import { generateWhatUserCaresAbout, type UserTopic } from '../../lib/analyze/interests';
 import { DurableObjectOAuthClientProvider } from 'agents/mcp/do-oauth-client-provider';
 import { AiChatPrompt, GmailSearchAssistantSystemPrompt } from '../../lib/prompts';
@@ -54,6 +54,7 @@ import { getPrompt } from '../../pipelines.effect';
 import { AIChatAgent } from 'agents/ai-chat-agent';
 import { DurableObject } from 'cloudflare:workers';
 import { ToolOrchestrator } from './orchestrator';
+import { eq, desc, isNotNull } from 'drizzle-orm';
 import migrations from './db/drizzle/migrations';
 import { getPromptName } from '../../pipelines';
 import { anthropic } from '@ai-sdk/anthropic';
@@ -70,7 +71,6 @@ import { Effect, pipe } from 'effect';
 import { groq } from '@ai-sdk/groq';
 import { createDb } from '../../db';
 import type { Message } from 'ai';
-import { eq, desc, isNotNull } from 'drizzle-orm';
 import { create } from './db';
 
 const decoder = new TextDecoder();
@@ -298,10 +298,10 @@ const _migrations = Object.fromEntries(
 @Migratable({
   migrations: {
     1: [
-      `CREATE TABLE IF NOT EXISTS shards (  
-      shard_id TEXT PRIMARY KEY,  
-      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,  
-      last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP  
+      `CREATE TABLE IF NOT EXISTS shards (
+      shard_id TEXT PRIMARY KEY,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      last_used TIMESTAMP DEFAULT CURRENT_TIMESTAMP
     )`,
     ],
   },
@@ -328,7 +328,10 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
   private agent: DurableObjectStub<ZeroAgent> | null = null;
   private name: string = 'general';
   private connection: typeof connection.$inferSelect | null = null;
-  private recipientCache: { contacts: Array<{ email: string; name?: string | null; freq: number; last: number }>; hash: string } | null = null;
+  private recipientCache: {
+    contacts: Array<{ email: string; name?: string | null; freq: number; last: number }>;
+    hash: string;
+  } | null = null;
 
   private invalidateRecipientCache() {
     this.recipientCache = null;
@@ -336,7 +339,7 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
 
   private parseMalformedSender(rawData: string): { email: string; name?: string } | null {
     const emailRegex = /([^\s@]+@[^\s@]+\.[^\s@]+)/;
-    
+
     if (emailRegex.test(rawData.trim())) {
       const email = rawData.trim();
       console.warn('[SuggestRecipients] Used fallback parsing for plain email:', email);
@@ -345,7 +348,7 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
 
     const emailMatch = rawData.match(emailRegex);
     if (!emailMatch) return null;
-    
+
     const email = emailMatch[1];
     let name: string | undefined = undefined;
 
@@ -876,6 +879,13 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
     return await this.driver.listDrafts(params);
   }
 
+  async deleteDraft(id: string) {
+    if (!this.driver) {
+      throw new Error('No driver available');
+    }
+    return await this.driver.deleteDraft(id);
+  }
+
   // Additional mail operations
   async count() {
     const folders = ['inbox', 'sent', 'spam', 'archive', 'trash'];
@@ -893,7 +903,6 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
     return `${this.name}/${threadId}.json`;
   }
 
- 
   async deleteThread(id: string) {
     await this.db.delete(threads).where(eq(threads.threadId, id));
     this.invalidateRecipientCache();
@@ -1505,24 +1514,37 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
 
   async suggestRecipients(query: string = '', limit: number = 10) {
     const lower = query.toLowerCase();
-    
-    const hashRows = await this.db.select({ id: threads.id }).from(threads).where(isNotNull(threads.latestSender)).orderBy(desc(threads.latestReceivedOn)).limit(100);
-    
-    const currentHash = hashRows.map(r => r.id).join(',');
-    
-    if (!this.recipientCache || this.recipientCache.hash !== currentHash) {
-      const rows = await this.db.select({ 
-        latest_sender: threads.latestSender, 
-        latest_received_on: threads.latestReceivedOn 
-      }).from(threads).where(isNotNull(threads.latestSender)).orderBy(desc(threads.latestReceivedOn)).limit(100);
 
-      const map = new Map<string, { email: string; name?: string | null; freq: number; last: number }>();
+    const hashRows = await this.db
+      .select({ id: threads.id })
+      .from(threads)
+      .where(isNotNull(threads.latestSender))
+      .orderBy(desc(threads.latestReceivedOn))
+      .limit(100);
+
+    const currentHash = hashRows.map((r) => r.id).join(',');
+
+    if (!this.recipientCache || this.recipientCache.hash !== currentHash) {
+      const rows = await this.db
+        .select({
+          latest_sender: threads.latestSender,
+          latest_received_on: threads.latestReceivedOn,
+        })
+        .from(threads)
+        .where(isNotNull(threads.latestSender))
+        .orderBy(desc(threads.latestReceivedOn))
+        .limit(100);
+
+      const map = new Map<
+        string,
+        { email: string; name?: string | null; freq: number; last: number }
+      >();
 
       for (const row of rows) {
         if (!row?.latest_sender) continue;
-        
+
         let sender: { email?: string; name?: string } | null = null;
-        
+
         try {
           const senderData = row.latest_sender;
           if (typeof senderData === 'string') {
@@ -1532,23 +1554,33 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
           } else {
             sender = this.parseMalformedSender(String(senderData));
           }
-          
+
           if (!sender) {
-            console.error('[SuggestRecipients] Failed to parse latest_sender, no fallback possible. Raw data:', row.latest_sender);
+            console.error(
+              '[SuggestRecipients] Failed to parse latest_sender, no fallback possible. Raw data:',
+              row.latest_sender,
+            );
             continue;
           }
         } catch (error) {
           sender = this.parseMalformedSender(String(row.latest_sender));
           if (!sender) {
-            console.error('[SuggestRecipients] Failed to parse latest_sender, no fallback possible:', error, 'Raw data:', row.latest_sender);
+            console.error(
+              '[SuggestRecipients] Failed to parse latest_sender, no fallback possible:',
+              error,
+              'Raw data:',
+              row.latest_sender,
+            );
             continue;
           }
         }
-        
+
         if (!sender?.email) continue;
 
         const key = sender.email.toLowerCase();
-        const lastTs = row.latest_received_on ? new Date(String(row.latest_received_on)).getTime() : 0;
+        const lastTs = row.latest_received_on
+          ? new Date(String(row.latest_received_on)).getTime()
+          : 0;
 
         if (!map.has(key)) {
           map.set(key, {
@@ -1575,8 +1607,7 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
     if (lower) {
       contacts = contacts.filter(
         (c) =>
-          c.email.toLowerCase().includes(lower) ||
-          (c.name && c.name.toLowerCase().includes(lower)),
+          c.email.toLowerCase().includes(lower) || (c.name && c.name.toLowerCase().includes(lower)),
       );
     }
 
@@ -1965,16 +1996,16 @@ export class ZeroAgent extends AIChatAgent<ZeroEnv> {
     try {
       const cached = await this.ctx.storage.get('do_state_cache');
       if (!cached) return null;
-      
+
       const data = cached as any;
       const now = Date.now();
       const CACHE_TTL = 5 * 60 * 1000;
-      
+
       if (now - data.timestamp > CACHE_TTL) {
         await this.ctx.storage.delete('do_state_cache');
         return null;
       }
-      
+
       return data;
     } catch (error) {
       console.error('[ZeroAgent] Failed to get cached DO state:', error);
@@ -1982,13 +2013,17 @@ export class ZeroAgent extends AIChatAgent<ZeroEnv> {
     }
   }
 
-  async setCachedDoState(storageSize: number, counts: { label: string; count: number }[], shards: number): Promise<void> {
+  async setCachedDoState(
+    storageSize: number,
+    counts: { label: string; count: number }[],
+    shards: number,
+  ): Promise<void> {
     try {
       const data = {
         storageSize,
         counts,
         shards,
-        timestamp: Date.now()
+        timestamp: Date.now(),
       };
       await this.ctx.storage.put('do_state_cache', data);
     } catch (error) {

--- a/apps/server/src/routes/agent/index.ts
+++ b/apps/server/src/routes/agent/index.ts
@@ -883,7 +883,10 @@ export class ZeroDriver extends DurableObject<ZeroEnv> {
     if (!this.driver) {
       throw new Error('No driver available');
     }
-    return await this.driver.deleteDraft(id);
+    await this.driver.deleteDraft(id);
+    // Broadcast drafts folder refresh
+    await this.reloadFolder('drafts');
+    return { success: true };
   }
 
   // Additional mail operations

--- a/apps/server/src/trpc/routes/drafts.ts
+++ b/apps/server/src/trpc/routes/drafts.ts
@@ -32,4 +32,16 @@ export const draftsRouter = router({
         ReturnType<MailManager['listDrafts']>
       >;
     }),
+  delete: activeDriverProcedure
+    .input(
+      z.object({
+        id: z.string(),
+      }),
+    )
+    .mutation(async ({ input, ctx }) => {
+      const { activeConnection } = ctx;
+      const { stub: agent } = await getZeroAgent(activeConnection.id);
+      await agent.deleteDraft(input.id);
+      return true;
+    }),
 });

--- a/apps/server/src/trpc/routes/drafts.ts
+++ b/apps/server/src/trpc/routes/drafts.ts
@@ -35,7 +35,7 @@ export const draftsRouter = router({
   delete: activeDriverProcedure
     .input(
       z.object({
-        id: z.string(),
+        id: z.string().min(1, 'id is required'),
       }),
     )
     .mutation(async ({ input, ctx }) => {


### PR DESCRIPTION
# Add ability to delete drafts

This PR adds the ability to delete drafts directly from the mail list interface. It implements:

1. A delete button that appears when hovering over draft items
2. Backend support for draft deletion in both Google and Microsoft mail providers
3. Optimistic UI updates to immediately remove deleted drafts from the view

The implementation follows the existing optimistic action pattern used for other mail operations, ensuring a consistent user experience.

## Type of Change

- ✨ New feature (non-breaking change which adds functionality)

## Areas Affected

- [x] Email Integration (Gmail, Outlook, etc.)
- [x] User Interface/Experience
- [x] API Endpoints

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Delete drafts directly from the mail list via a new trash icon on each draft.
  - Immediate, optimistic removal of deleted drafts from the list for faster feedback.
  - Contextual tooltips on draft actions for clearer guidance.

- Bug Fixes
  - Corrected a visual offset issue in the action bar for consistent positioning.
  - Improved range selection behavior for multi-select actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->