### PR TITLE
fixed the issue Can't see text in email

### DIFF
--- a/apps/mail/components/mail/mail-content.tsx
+++ b/apps/mail/components/mail/mail-content.tsx
@@ -200,7 +200,7 @@ export function MailContent({ id, html, senderEmail }: MailContentProps) {
           </button>
         </div>
       )}
-      <div ref={hostRef} className={cn('mail-content w-full flex-1 overflow-scroll no-scrollbar px-4')} />
+      <div ref={hostRef} className={cn('mail-content w-full flex-1 overflow-scroll no-scrollbar px-4 text-black dark:text-white')} />
     </>
   );
 }


### PR DESCRIPTION


Description:

Problem:
In the mail content view, email text appeared white on a white background in light theme, making it unreadable. This happened because no explicit text color was set, so the default white text from dark theme styling carried over.

Steps to Reproduce:
1. Open any email in light mode.
2. Observe that the text blends into the white background.

Expected Behavior:
Text should be clearly visible (black in light mode, white in dark mode).

Solution:
Added explicit Tailwind classes text-black and dark:text-white to ensure correct text color is applied depending on the active theme.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed email text visibility by setting the text color to black in light mode and white in dark mode for better readability.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Updated Mail content to explicitly apply text colors for light and dark themes, ensuring consistent, higher-contrast readability across modes.
  - Visual-only change: no impact to data, performance, shortcuts, or navigation; all behaviors, layouts, and APIs remain unchanged.
  - Prevents cases where text could inherit unintended colors from parent containers, particularly in dark mode, improving overall clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->