### PR TITLE
filering of email addresses

### DIFF
--- a/apps/server/src/thread-workflow-utils/index.ts
+++ b/apps/server/src/thread-workflow-utils/index.ts
@@ -3,6 +3,15 @@ import { composeEmail } from '../trpc/routes/ai/compose';
 import { type ParsedMessage } from '../types';
 import { connection } from '../db/schema';
 
+const dontReplyTo = new Set([
+  'no-reply@gmail.com',
+  'noreply@gmail.com',
+  'do-not-reply@gmail.com',
+  'do-not-reply@gmail.com',
+  'notifications@github.com',
+  'info@e-mail.xing.com',
+]);
+
 const shouldGenerateDraft = async (
   thread: IGetThreadResponse,
   foundConnection: typeof connection.$inferSelect,
@@ -35,6 +44,11 @@ const shouldGenerateDraft = async (
     console.log(
       '[SHOULD_GENERATE_DRAFT] Message is likely automated or not actionable, skipping draft',
     );
+    return false;
+  }
+
+  if (dontReplyTo.has(senderEmail)) {
+    console.log('[SHOULD_GENERATE_DRAFT] Message is from a dont reply to email, skipping draft');
     return false;
   }
 


### PR DESCRIPTION
# Skip draft generation for no-reply email addresses

## Description

Added a check to prevent generating draft replies for messages from no-reply email addresses. This change introduces a set of common no-reply email addresses (like no-reply@gmail.com, notifications@github.com, etc.) and skips draft generation when the sender's email matches any of these addresses.

## Type of Change

- [x] ✨ New feature (non-breaking change which adds functionality)
- [x] ⚡ Performance improvement

## Areas Affected

- [x] Email Integration (Gmail, IMAP, etc.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevents auto-draft suggestions for emails from non-actionable senders (e.g., no-reply/noreply/do-not-reply and common notification services).
  * Reduces noise and avoids prompting replies where none are expected, improving relevance.
  * Applies the check earlier in the decision flow to stop drafts sooner, saving time.
  * No changes to user settings or visible controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->