### PR TITLE
 fix: show hand cursor on all buttons

### DIFF
--- a/apps/mail/components/ui/button.tsx
+++ b/apps/mail/components/ui/button.tsx
@@ -5,8 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 aria-busy:cursor-progress',
-  {
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 aria-busy:cursor-progress cursor-pointer',
     variants: {
       variant: {
         default: 'bg-primary text-primary-foreground hover:bg-primary/90',


### PR DESCRIPTION
Added cursor-pointer to the base Button component so all buttons show a hand on hover. Improves click feedback everywhere.


    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Added cursor-pointer to the base Button component so all buttons show a hand cursor on hover, improving click feedback across the app.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Buttons now display a pointer cursor by default, improving the visual cue for clickability across the mail interface.
  * Applies consistently to all button variants and sizes for a uniform experience.
  * Visual/interaction-only change; no adjustments to functionality or settings are required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->