### PR TITLE
Fix/duplicate privacy option in navigation menu in mobile view and inconsistent vertical spacing in the navigation links

### DIFF
--- a/apps/mail/components/navigation.tsx
+++ b/apps/mail/components/navigation.tsx
@@ -249,9 +249,6 @@ export function Navigation() {
                 <Link to="/pricing" className="mt-2" onClick={() => setOpen(false)}>
                   Pricing
                 </Link>
-                <Link to="/privacy" className="mt-2" onClick={() => setOpen(false)}>
-                  Privacy
-                </Link>
                 {aboutLinks.map((link) => (
                   <a key={link.title} href={link.href} className="block font-medium">
                     {link.title}

--- a/apps/mail/components/navigation.tsx
+++ b/apps/mail/components/navigation.tsx
@@ -243,10 +243,10 @@ export function Navigation() {
             </SheetHeader>
             <div className="mt-8 flex flex-col space-y-3">
               <div className="flex flex-col space-y-3">
-                <Link to="/" className="mt-2" onClick={() => setOpen(false)}>
+                <Link to="/" onClick={() => setOpen(false)}>
                   Home
                 </Link>
-                <Link to="/pricing" className="mt-2" onClick={() => setOpen(false)}>
+                <Link to="/pricing" onClick={() => setOpen(false)}>
                   Pricing
                 </Link>
                 {aboutLinks.map((link) => (


### PR DESCRIPTION
## Description

This PR fixes the inconsistent vertical spacing in the navigation links in the mobile view by removing the extra margin (mt-2) and relying only on space-y-3. Also, there was one duplicate **Privacy** option which was removed.
## Type of Change


- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🎨 UI/UX improvement

## Areas Affected
UI/UX

Please check all that apply:

- [x] User Interface/Experience

## Testing Done

Describe the tests you've done:

- [ ] Manual testing performed
- [x] Mobile responsiveness verified (if UI changes)


## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published


## Screenshots/Recordings

**Current behaviour**
<img width="471" height="539" alt="Screenshot from 2025-08-24 17-21-49" src="https://github.com/user-attachments/assets/5178008e-8440-4434-9861-dca0c70e66bb" />

**Expected behaviour**
<img width="449" height="483" alt="Screenshot from 2025-08-24 17-21-10" src="https://github.com/user-attachments/assets/4c236d56-ab4f-4259-befc-a5e8d6cea65f" />


_By submitting this pull request, I confirm that my contribution is made under the terms of the project's license._

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes mobile navigation by removing a duplicate Privacy link and normalizing vertical spacing between links. Dropped per-link mt-2 in favor of space-y-3 for consistent spacing.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Removed duplicate Privacy link from the mobile navigation sheet; it remains accessible via About links.
- Style
  - Reduced vertical spacing for Home and Pricing in the mobile navigation by removing extra top margin, improving visual compactness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->