### PR TITLE
fix(button): remove wrong hover classes to restore default hover behaviour

### DIFF
--- a/apps/mail/components/navigation.tsx
+++ b/apps/mail/components/navigation.tsx
@@ -189,7 +189,7 @@ export function Navigation() {
               </div>
             </a>
             <Button
-              className="h-8 bg-white text-black hover:bg-white hover:text-black cursor-pointer"
+              className="h-8 bg-white text-black cursor-pointer"
               onClick={() => {
                 if (session) {
                   navigate('/mail/inbox');


### PR DESCRIPTION



## Description

This PR removes the buggy hover class to add the default hover behaviour to make it consistent with the other "Get Started" button in the landing page.
The cursor pointer class was already there. "hover:bg-white hover:text-black" class was there which makes no sense since the default background color and text color were white and black respectively.

## Type of Change

Please delete options that are not relevant.

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] 🎨 UI/UX improvement

## Areas Affected

Please check all that apply:

- [ ] Email Integration (Gmail, IMAP, etc.)
- [ ] User Interface/Experience
- [ ] Authentication/Authorization
- [ ] Data Storage/Management
- [ ] API Endpoints
- [ ] Documentation
- [ ] Testing Infrastructure
- [ ] Development Workflow
- [ ] Deployment/Infrastructure

## Testing Done

Describe the tests you've done:

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] Cross-browser testing (if UI changes)
- [ ] Mobile responsiveness verified (if UI changes)

## Security Considerations

For changes involving data or authentication:

- [ ] No sensitive data is exposed
- [ ] Authentication checks are in place
- [ ] Input validation is implemented
- [ ] Rate limiting is considered (if applicable)

## Checklist

- [ ] I have read the [CONTRIBUTING](https://github.com/Mail-0/Zero/blob/staging/.github/CONTRIBUTING.md) document
- [ ] My code follows the project's style guidelines
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in complex areas
- [ ] I have updated the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] All tests pass locally
- [ ] Any dependent changes are merged and published


## Screenshots/Recordings


https://github.com/user-attachments/assets/89705957-5844-4a86-b33a-62defc90f85f




    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Removed incorrect hover classes from the “Get Started” button to restore default hover behavior and match the landing page button. Keeps the pointer cursor and removes redundant bg/text overrides.

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined “Get Started” button styling in the navigation by removing hover color changes, keeping a consistent white background and black text.
  * No functional changes: clicking still opens Inbox for signed-in users or starts the sign-in flow if not.
  * Improves visual consistency and reduces distracting hover flicker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->