### PR TITLE
fix typos in MCP.md and HomeContent.tsx

### DIFF
--- a/MCP.md
+++ b/MCP.md
@@ -39,7 +39,7 @@ Zero MCP provides the following capabilities:
 
 ## How to use?
 
-You can connecto ZeroMCP using two methods:
+You can connect to ZeroMCP using two methods:
 
 1. Better Auth session token
 2. OAuth (Coming soon)

--- a/apps/mail/components/home/HomeContent.tsx
+++ b/apps/mail/components/home/HomeContent.tsx
@@ -1032,7 +1032,7 @@ export default function HomeContent() {
               <h1 className="mb-2 text-lg font-medium leading-loose text-white">Smart Search</h1>
               <p className="max-w-sm text-sm font-light text-[#979797]">
                 Your inbox, your rules. Create personalized email processing flows that match
-                exactly how you organize,write, reply, and work.
+                exactly how you organize, write, reply, and work.
               </p>
             </div>
           </motion.div>


### PR DESCRIPTION
Fixed a typo in the “How to use?” section of `MCP.md` (changed `connecto` to `connect to`).
Added a trailing space after the comma in `HomeContent.tsx` under the Smart Search feature description.