### PR TITLE
fix: optional chaining when accessing session user id

### DIFF
--- a/apps/mail/hooks/use-settings.ts
+++ b/apps/mail/hooks/use-settings.ts
@@ -8,7 +8,7 @@ export function useSettings() {
 
   const settingsQuery = useQuery(
     trpc.settings.get.queryOptions(void 0, {
-      enabled: !!session?.user.id,
+      enabled: !!session?.user?.id,
       staleTime: Infinity,
     }),
   );


### PR DESCRIPTION
This change prevents a potential runtime error when accessing `session.user.id`.

Previously:
session?.user.id

If `session.user` was undefined, this could throw.

This update safely accesses the value using: 
session?.user?.id